### PR TITLE
feat: add SEL to stock symbols

### DIFF
--- a/src/utils/constants/stockSymbols.ts
+++ b/src/utils/constants/stockSymbols.ts
@@ -3784,6 +3784,14 @@ export const STOCKS_INFO = [
     isGEM: false,
   },
   {
+    "symbol": "WAHDAT",
+    "name": "Wahdat Poultry Farm Limited",
+    "sectorName": "FOOD & PERSONAL CARE PRODUCTS",
+    "isETF": false,
+    "isDebt": false,
+    "isGEM": false
+  },
+  {
     symbol: "WAHN",
     name: "Wah Noble Chemicals Limited",
     sectorName: "CHEMICAL",


### PR DESCRIPTION
### TL;DR

Added WAHDAT (Wahdat Poultry Farm Limited) to the stock symbols list.

### What changed?

Added a new stock entry for **WAHDAT** (Wahdat Poultry Farm Limited) under the **Food & Personal Care Products** sector. The stock is classified as a standard equity (not an ETF, debt instrument, or GEM listing).

### How to test?

Search for `WAHDAT` in the application and verify that **Wahdat Poultry Farm Limited** appears with the correct sector classification of **Food & Personal Care Products**.

### Why make this change?

To keep the stock symbols list up to date by including Wahdat Poultry Farm Limited, which is a listed company that was previously missing from the dataset.