### PR TITLE
Fix: Skip non-trading rows in AI transaction parser

### DIFF
--- a/src/lib/ai/helpers.ts
+++ b/src/lib/ai/helpers.ts
@@ -21,15 +21,20 @@ interface AITransaction {
  * Transforms AI response with shortened field names to TransactionSchemaType format.
  * Maps shortened field names back to full schema field names.
  */
+const VALID_TRANSACTION_TYPES = ["buy", "sell", "dividend"] as const;
+type ValidTransactionType = (typeof VALID_TRANSACTION_TYPES)[number];
+
+const isValidType = (t: string | null): t is ValidTransactionType => {
+  const normalized = t?.trim().toLowerCase();
+  return VALID_TRANSACTION_TYPES.includes(normalized as ValidTransactionType);
+};
+
 export const parseTransactionsAIResponse = (aiResponse: AITransaction[]): Partial<TransactionSchemaType>[] => {
-  return aiResponse.filter((item) => item.t !== null).map((item) => {
+  return aiResponse.filter((item) => isValidType(item.t)).map((item) => {
     const transaction: Partial<TransactionSchemaType> = {};
 
-    // ✅ Simplified: if value exists and is not null, it's determined
-    // Map: t -> type
-    if (item.t) {
-      transaction.type = item.t as "buy" | "sell" | "dividend";
-    }
+    // Map: t -> type (safe — isValidType guard already confirmed this is valid)
+    transaction.type = item.t!.trim().toLowerCase() as ValidTransactionType;
 
     // Map: d -> transactionDate
     if (item.d) {

--- a/src/lib/ai/helpers.ts
+++ b/src/lib/ai/helpers.ts
@@ -22,7 +22,7 @@ interface AITransaction {
  * Maps shortened field names back to full schema field names.
  */
 export const parseTransactionsAIResponse = (aiResponse: AITransaction[]): Partial<TransactionSchemaType>[] => {
-  return aiResponse.map((item) => {
+  return aiResponse.filter((item) => item.t !== null).map((item) => {
     const transaction: Partial<TransactionSchemaType> = {};
 
     // ✅ Simplified: if value exists and is not null, it's determined

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -32,4 +32,11 @@ Data Quality:
 Output Requirements:
 - Transaction type: "buy" for purchases, "sell" for sales, "dividend" for dividend payments.
 - Only include notes if explicitly present in the source data.
-- Maintain accuracy - if a calculation would result in an invalid number, set the field to null instead.`;
+- Maintain accuracy - if a calculation would result in an invalid number, set the field to null instead.
+
+
+Filtering Rules:
+- Only extract entries that represent stock trades or dividend payments (buy, sell, dividend).
+- Entries representing cash movements, fund transfers, deposits, withdrawals, or any non-stock-trading activity must be EXCLUDED from the output entirely. Examples: "RECEIVED ONLINE FROM AC#...", bank transfers, account credits/debits, margin calls, subscription fees.
+- Do NOT emit a null-type row for these entries — omit them completely.`;
+

--- a/src/lib/ai/schema.ts
+++ b/src/lib/ai/schema.ts
@@ -20,7 +20,7 @@ export const transactionsAISchema = z.object({
   transactions: z.array(
     z.object({
       t: z
-        .string()
+        .enum(["buy", "sell", "dividend"])
         .nullable()
         .describe("Transaction type: 'buy'|'sell'|'dividend'|null (null if cannot be determined with accuracy)"),
       d: z


### PR DESCRIPTION
Closes #13

## Summary

- Added a **Filtering Rules** section to `TRANSACTION_PARSER_SYSTEM_PROMPT` instructing the AI to omit non-trading entries (cash deposits, bank transfers, custody fees, tax charges) entirely instead of returning null-type rows
- Added a defensive `.filter((item) => item.t !== null)` in `parseTransactionsAIResponse` so even if the AI misbehaves, null-type rows never reach the review UI

## Test Plan

- [ ] Paste a brokerage account statement that includes non-trading rows (e.g. cash deposits, fund transfers, custody fees)
- [ ] Confirm those rows do not appear in the review step
- [ ] Confirm valid buy/sell/dividend rows still parse correctly