### PR TITLE
fix(import): avoid programmatic trigger() to prevent validation races…

### DIFF
--- a/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
@@ -52,33 +52,22 @@ export function TransactionPreviewCard({
     control,
     watch,
     formState: { errors },
-    trigger,
     clearErrors,
   } = hookForm;
 
   const watchedTransaction = watch();
 
-  //Trigger form validation manually because our transaction can have invalid fields.
-  useEffect(() => {
-    trigger(); // Validates all fields
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (watchedTransaction.transactionDate) {
-      trigger("transactionDate");
-    }
-  }, [watchedTransaction.transactionDate, trigger]);
-
   /**
-   * Re-validate stock symbol field when it changes to clear persistent errors
+   * Clear stock symbol errors when it changes to avoid persistent errors
    */
   useEffect(() => {
     if (watchedTransaction.stockSymbol) {
+      // Clear previous symbol errors when user selects/enters a symbol.
+      // Avoid forcing validation here to prevent overlapping trigger races —
+      // rely on user-driven validation (mode: "onBlur") to re-validate the field.
       clearErrors("stockSymbol");
-      trigger("stockSymbol");
     }
-  }, [watchedTransaction.stockSymbol, clearErrors, trigger]);
+    }, [watchedTransaction.stockSymbol, clearErrors]);
 
   /**
    * Give the updated transaction to the parent component. It can then use this for example, for checking

--- a/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
@@ -61,13 +61,10 @@ export function TransactionPreviewCard({
    * Clear stock symbol errors when it changes to avoid persistent errors
    */
   useEffect(() => {
-    if (watchedTransaction.stockSymbol) {
-      // Clear previous symbol errors when user selects/enters a symbol.
-      // Avoid forcing validation here to prevent overlapping trigger races —
-      // rely on user-driven validation (mode: "onBlur") to re-validate the field.
-      clearErrors("stockSymbol");
-    }
-    }, [watchedTransaction.stockSymbol, clearErrors]);
+    // Clear previous symbol errors whenever symbol value changes,
+    // including when it becomes empty, to avoid stale errors.
+    clearErrors("stockSymbol");
+  }, [watchedTransaction.stockSymbol, clearErrors]);
 
   /**
    * Give the updated transaction to the parent component. It can then use this for example, for checking


### PR DESCRIPTION
… in TransactionPreviewCard

Fix(validation): stop programmatic validation triggers to prevent flicker in Import Transactions

<!-- Brief description of the change -->
What

- Removed automatic programmatic validation that ran on render and from several field effects.
- Kept only user-driven validation so errors appear after the user interacts with a field.
- Note: a resilient fallback parser was discussed earlier, but it is not included in this PR (this PR is focused on the validation fix only).

Why

- The review card called trigger() on mount and multiple effects also retriggered validation. When users pasted values or edited quickly, these overlapping validation runs caused errors to flicker or persist even when values were valid.
- Switching to user-driven onBlur validation removes those race conditions and makes copy/paste and quick edits predictable.

<!-- The motivation: linked issue, bug being fixed, feature being added -->

Closes #15 

## Testing

Run: pnpm dev
Go to a portfolio → Import Transactions
Paste sample transactions and click “Process Data”
In the Review step open a transaction and click Edit
Copy a numeric value, paste it into another field, then move focus away (blur)
Expected: validation runs on blur only; no flicker; errors clear once the value is valid


## Checklist

- PR target branch: develop
- Linked issue: #15
- I am assigned to the linked issue
- Lint passed: pnpm lint
- Type checks passed: pnpm lint:types or pnpm tsc --noEmit
- Tests passed (if any): pnpm test
- Manual verification done (steps above)
- Screenshots / short video attached (if needed)
- CI checks are green
