### PR TITLE
fix(validation): remove programmatic trigger calls; clear stockSymbol…

### DIFF
--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/components/StockSelect.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/components/StockSelect.tsx
@@ -11,7 +11,7 @@ import { STOCKS_INFO } from "@/utils/constants/stockSymbols";
 import { ChevronsUpDown, Check, Search } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useState } from "react";
-import { ControllerRenderProps, FieldValues, Path } from "react-hook-form";
+import { ControllerRenderProps, FieldValues, Path, useFormContext } from "react-hook-form";
 
 interface StockSelectProps<TFieldValues extends FieldValues> {
   field: ControllerRenderProps<TFieldValues, Path<TFieldValues>>;
@@ -20,6 +20,7 @@ interface StockSelectProps<TFieldValues extends FieldValues> {
 export function StockSelect<TFieldValues extends FieldValues>({ field }: StockSelectProps<TFieldValues>) {
   "use no memo";
   const { error } = useFormField();
+  const { clearErrors, formState, getFieldState } = useFormContext<TFieldValues>();
 
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
@@ -33,6 +34,12 @@ export function StockSelect<TFieldValues extends FieldValues>({ field }: StockSe
       );
 
   const handleSelect = (stockSymbol: string) => {
+    const fieldState = getFieldState(field.name, formState);
+
+    if (error || fieldState.isDirty || fieldState.isTouched) {
+      clearErrors(field.name as Path<TFieldValues>);
+    }
+
     field.onChange(stockSymbol);
     setOpen(false);
     setSearchValue("");

--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/components/StockSelect.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/components/StockSelect.tsx
@@ -20,7 +20,7 @@ interface StockSelectProps<TFieldValues extends FieldValues> {
 export function StockSelect<TFieldValues extends FieldValues>({ field }: StockSelectProps<TFieldValues>) {
   "use no memo";
   const { error } = useFormField();
-  const { clearErrors, formState, getFieldState } = useFormContext<TFieldValues>();
+  const { clearErrors } = useFormContext<TFieldValues>();
 
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
@@ -34,9 +34,7 @@ export function StockSelect<TFieldValues extends FieldValues>({ field }: StockSe
       );
 
   const handleSelect = (stockSymbol: string) => {
-    const fieldState = getFieldState(field.name, formState);
-
-    if (error || fieldState.isDirty || fieldState.isTouched) {
+    if (error) {
       clearErrors(field.name as Path<TFieldValues>);
     }
 

--- a/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
@@ -52,33 +52,19 @@ export function TransactionPreviewCard({
     control,
     watch,
     formState: { errors },
-    trigger,
     clearErrors,
   } = hookForm;
 
   const watchedTransaction = watch();
 
-  //Trigger form validation manually because our transaction can have invalid fields.
-  useEffect(() => {
-    trigger(); // Validates all fields
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (watchedTransaction.transactionDate) {
-      trigger("transactionDate");
-    }
-  }, [watchedTransaction.transactionDate, trigger]);
-
   /**
-   * Re-validate stock symbol field when it changes to clear persistent errors
+   * Clear stock symbol errors whenever the value changes (including emptying the field)
+   * to avoid stale/persistent errors caused by overlapping programmatic validations.
+   * Rely on user-driven validation (`mode: "onBlur"`) to perform actual validation.
    */
   useEffect(() => {
-    if (watchedTransaction.stockSymbol) {
-      clearErrors("stockSymbol");
-      trigger("stockSymbol");
-    }
-  }, [watchedTransaction.stockSymbol, clearErrors, trigger]);
+    clearErrors("stockSymbol");
+  }, [watchedTransaction.stockSymbol, clearErrors]);
 
   /**
    * Give the updated transaction to the parent component. It can then use this for example, for checking

--- a/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
@@ -52,19 +52,9 @@ export function TransactionPreviewCard({
     control,
     watch,
     formState: { errors },
-    clearErrors,
   } = hookForm;
 
   const watchedTransaction = watch();
-
-  /**
-   * Clear stock symbol errors whenever the value changes (including emptying the field)
-   * to avoid stale/persistent errors caused by overlapping programmatic validations.
-   * Rely on user-driven validation (`mode: "onBlur"`) to perform actual validation.
-   */
-  useEffect(() => {
-    clearErrors("stockSymbol");
-  }, [watchedTransaction.stockSymbol, clearErrors]);
 
   /**
    * Give the updated transaction to the parent component. It can then use this for example, for checking

--- a/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
@@ -51,10 +51,10 @@ export function TransactionPreviewCard({
   const {
     control,
     watch,
-    formState: { errors },
   } = hookForm;
 
   const watchedTransaction = watch();
+  const validationResult = transactionSchema.safeParse(watchedTransaction);
 
   /**
    * Give the updated transaction to the parent component. It can then use this for example, for checking
@@ -65,8 +65,7 @@ export function TransactionPreviewCard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(watchedTransaction)]);
 
-  const validationErrors = Object.keys(errors).length;
-  const isValid = !validationErrors;
+  const isValid = validationResult.success;
 
   return (
     <FormProvider {...hookForm}>


### PR DESCRIPTION
… errors on change

Removed all programmatic trigger() calls from the Import → Review form flow in TransactionPreviewCard.
Also removed trigger from useForm destructuring and adjusted validation handling so that errors are no longer controlled by multiple competing triggers.
Added controlled clearErrors("stockSymbol") behavior tied only to actual stockSymbol value changes to prevent stale validation state.

<!-- Brief description of the change -->

Programmatic trigger() calls were causing race conditions with React Hook Form’s mode: "onBlur" validation.
Multiple sources were triggering validation simultaneously:

- trigger() on component mount
- onBlur validation mode
- useEffect watchers on stockSymbol and watchedTransaction
- paste/change events triggering additional validation cycles

This resulted in:

- 
- flickering validation errors
- stale error states after correction
- errors persisting even when values were valid

This change simplifies validation flow by relying on user-driven events only and removing overlapping programmatic validation triggers.

<!-- The motivation: linked issue, bug being fixed, feature being added -->

Closes #15 

## Testing

Local static checks

pnpm lint — passed
pnpm lint:types — passed

Code verification
Searched codebase for remaining trigger() usage affecting validation flow — none found

Manual QA steps

- Started dev server
- Opened Import Transactions → Review
- Pasted/imported transactions that previously caused validation flicker
- Edited stockSymbol field and blurred input

Expected result

- Validation errors clear immediately on valid input
- No flickering or reappearing errors
- No stale validation state after edits or paste actions

## Checklist

- 
-  PR targets develop (not main)
-  I'm assigned to the linked issue (#15)
-  Branch name follows feature/fix convention (fix/transaction-validation-race-condition)
-  pnpm lint passes locally without errors
-  pnpm lint:types passes locally without errors
-  Manual testing completed for Import → Review validation flow
-  No regression introduced in form validation behavior
-  Removed conflicting trigger() calls causing race conditions
-  Verified error states do not flicker or persist incorrectly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Submit button now correctly reflects transaction validity and no longer triggers redundant re-validation on load.
  * Stock selection clears stale field errors and reliably updates the field state when a stock is chosen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wajahat43/psxworth/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->