### PR TITLE
feat: icon-only buttons on transaction preview card

### DIFF
--- a/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionPreviewCard.tsx
@@ -1,9 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { toLocalDate } from "@/types/localDate";
 import { transactionSchema, TransactionSchemaType } from "@/types";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Edit3, Check, Database, Loader2, CheckCircle, AlertCircle, Trash2 } from "lucide-react";
+import { Edit3, Check, Plus, Loader2, CheckCircle, AlertCircle, Trash2 } from "lucide-react";
 import React, { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { twMerge } from "tailwind-merge";
@@ -102,53 +103,66 @@ export function TransactionPreviewCard({
             isProcessed ? "border-primary/40" : ""
           )}
         >
-          <div className="flex items-center justify-between gap-2 md:gap-12">
+          <div className="flex items-center justify-between gap-2 md:gap-8">
             <TransactionSummary transaction={watchedTransaction} />
-            <div className="flex items-center gap-2 flex-col-reverse md:flex-row">
+            <div className="flex items-center gap-1">
               {!isProcessed && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={onRemoveTransaction}
-                  className="flex items-center gap-2 border-slate-700 bg-slate-800/60 text-slate-200 hover:bg-red-900/40 hover:text-red-100"
-                  disabled={isLoading || isEditing}
-                >
-                  <Trash2 className="h-3 w-3" />
-                  Remove
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={onRemoveTransaction}
+                      className="h-8 w-8 border-slate-700 bg-slate-800/60 text-slate-200 hover:bg-red-900/40 hover:text-red-100"
+                      disabled={isLoading || isEditing}
+                      aria-label="Remove transaction"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Remove</TooltipContent>
+                </Tooltip>
               )}
 
               {!isProcessed && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setIsEditing(!isEditing)}
-                  className="flex items-center gap-2 border-slate-700 bg-slate-800/60 text-slate-200 hover:bg-blue-900/40 hover:text-slate-100"
-                  disabled={isLoading}
-                >
-                  {isEditing ? (
-                    <>
-                      <Check className="h-3 w-3" />
-                      Done
-                    </>
-                  ) : (
-                    <>
-                      <Edit3 className="h-3 w-3" />
-                      Edit
-                    </>
-                  )}
-                </Button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      onClick={() => setIsEditing(!isEditing)}
+                      className="h-8 w-8 border-slate-700 bg-slate-800/60 text-slate-200 hover:bg-blue-900/40 hover:text-slate-100"
+                      disabled={isLoading}
+                      aria-label={isEditing ? "Done editing" : "Edit transaction"}
+                    >
+                      {isEditing ? <Check className="h-4 w-4" /> : <Edit3 className="h-4 w-4" />}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{isEditing ? "Done" : "Edit"}</TooltipContent>
+                </Tooltip>
               )}
 
-              <Button
-                size="sm"
-                variant={isProcessed ? "default" : isValid ? "default" : "destructive"}
-                onClick={() => onSubmitTransaction(watchedTransaction)}
-                disabled={isLoading || !isValid || isEditing || isProcessed}
-                className={isProcessed ? "bg-background border-primary hover:bg-primary/80" : ""}
-              >
-                {getButtonContent(isLoading, isValid, isProcessed)}
-              </Button>
+              <Tooltip>
+                {/* Span wrapper so the tooltip still fires when the button is disabled
+                    (disabled <button> elements swallow pointer events). */}
+                <TooltipTrigger asChild>
+                  <span className="inline-flex">
+                    <Button
+                      size="icon"
+                      variant={isProcessed ? "default" : isValid ? "default" : "destructive"}
+                      onClick={() => onSubmitTransaction(watchedTransaction)}
+                      disabled={isLoading || !isValid || isEditing || isProcessed}
+                      className={twMerge("h-8 w-8", isProcessed && "bg-background border-primary hover:bg-primary/80")}
+                      aria-label={getButtonAriaLabel(isLoading, isValid, isProcessed, errors)}
+                    >
+                      {getButtonIcon(isLoading, isValid, isProcessed)}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[240px]">
+                  {getButtonTooltip(isLoading, isValid, isProcessed, errors)}
+                </TooltipContent>
+              </Tooltip>
             </div>
           </div>
 
@@ -161,33 +175,56 @@ export function TransactionPreviewCard({
   );
 }
 
-function getButtonContent(isLoading: boolean, isValid: boolean, isProcessed: boolean) {
-  if (isLoading) {
-    return <Loader2 className="h-3 w-3 animate-spin" />;
-  }
+type ErrorsRecord = Partial<Record<string, { message?: string } | undefined>>;
 
+const FIELD_LABELS: Record<string, string> = {
+  stockSymbol: "Stock symbol",
+  numberOfShares: "Number of shares",
+  pricePerShare: "Price per share",
+  dividendPerShare: "Dividend per share",
+  transactionDate: "Transaction date",
+  commissionAndTaxes: "Commission/taxes",
+};
+
+function getInvalidFieldMessages(errors: ErrorsRecord): string[] {
+  return Object.entries(errors).flatMap(([field, error]) => {
+    if (!error) return [];
+    const label = FIELD_LABELS[field] ?? field;
+    return [error.message ? `${label}: ${error.message}` : label];
+  });
+}
+
+function getButtonIcon(isLoading: boolean, isValid: boolean, isProcessed: boolean) {
+  if (isLoading) return <Loader2 className="h-4 w-4 animate-spin" />;
+  if (isProcessed) return <CheckCircle className="h-4 w-4" />;
+  if (!isValid) return <AlertCircle className="h-4 w-4" />;
+  return <Plus className="h-4 w-4" />;
+}
+
+function getButtonAriaLabel(isLoading: boolean, isValid: boolean, isProcessed: boolean, errors: ErrorsRecord) {
+  if (isLoading) return "Adding…";
+  if (isProcessed) return "Added";
   if (!isValid) {
-    return (
-      <>
-        <AlertCircle className="h-3 w-3 mr-1" />
-        Invalid
-      </>
-    );
+    const messages = getInvalidFieldMessages(errors);
+    return messages.length ? `Invalid: ${messages.join("; ")}` : "Invalid — fix errors to add";
   }
+  return "Add transaction";
+}
 
-  if (isProcessed) {
-    return (
-      <>
-        <CheckCircle className="h-3 w-3 mr-1" />
-        Added
-      </>
-    );
-  }
+function getButtonTooltip(isLoading: boolean, isValid: boolean, isProcessed: boolean, errors: ErrorsRecord) {
+  if (isLoading) return "Adding…";
+  if (isProcessed) return "Added";
+  if (isValid) return "Add transaction";
+
+  const messages = getInvalidFieldMessages(errors);
+  if (!messages.length) return "Fix the highlighted errors to add this transaction";
 
   return (
-    <>
-      <Database className="h-3 w-3 mr-1" />
-      Add
-    </>
+    <div className="flex flex-col gap-0.5">
+      <span className="font-medium">Fix to add:</span>
+      {messages.map((m) => (
+        <span key={m}>• {m}</span>
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## What changed

Replaced the text-and-icon `Remove`, `Edit`, and `Add` buttons on `TransactionPreviewCard` with icon-only buttons (32×32). Each button has a tooltip on hover.

The invalid-state button now lists the specific field errors in its tooltip (e.g. "Stock symbol: Invalid stock symbol") instead of a generic message, so users know what to fix without clicking into edit mode.

## Why

The action area on each card was taking ~280px (much more than needed). Icon-only buttons reduce it to ~104px, freeing space for the transaction summary — especially noticeable on mobile.

## Screenshots

Before
<img width="630" height="279" alt="Screenshot 2026-05-23 at 11 08 25 PM" src="https://github.com/user-attachments/assets/528a8abb-6107-4bdc-9922-b891d3b75ebc" />

After
<img width="629" height="350" alt="Screenshot 2026-05-23 at 11 08 48 PM" src="https://github.com/user-attachments/assets/53797101-d32c-43a4-8600-1a8053dd7987" />

## Test plan

- [ ] Open the import-transactions flow with a mix of valid and invalid parsed transactions
- [ ] Hover each icon (remove/edit/add) and confirm the tooltip shows the action label
- [ ] On an invalid card, hover the red alert icon — tooltip lists the specific field errors
- [ ] Confirm the icon-only layout looks clean on both mobile and desktop widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to transaction action buttons for improved guidance.
  * Enhanced validation error messaging to display specific field issues.

* **Style**
  * Redesigned transaction preview card with icon-only action buttons.
  * Updated submit button styling to reflect processing states (loading, completed, error).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wajahat43/psxworth/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->