### PR TITLE
fix: Update layout and styling for transaction review component

### DIFF
--- a/src/components/organisms/ImportTransactions/components/MultipleTransactionsReview/MultipleTransactionsReview.tsx
+++ b/src/components/organisms/ImportTransactions/components/MultipleTransactionsReview/MultipleTransactionsReview.tsx
@@ -113,15 +113,15 @@ export function MultipleTransactionsReview({ transactions, onPrevious, onClose }
     hasTransactions && reviewTransactions.every(({ reviewId }) => submittedTransactions.has(reviewId));
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between flex-shrink-0">
         <div>
           <h3 className="text-lg font-semibold text-slate-100">Transaction Review</h3>
           <p className="text-sm text-slate-400">Review your transactions and complete any missing information</p>
         </div>
       </div>
 
-      <div className="space-y-4">
+      <div className="space-y-4 overflow-y-auto max-h-[55vh] -mx-2 px-2">
         {!hasTransactions && (
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <FileX className="h-12 w-12 text-slate-500 mb-4" />
@@ -152,9 +152,7 @@ export function MultipleTransactionsReview({ transactions, onPrevious, onClose }
         ))}
       </div>
 
-      <div className="h-px bg-slate-700" />
-
-      <div className="flex justify-between items-center gap-2">
+      <div className="flex justify-between items-center gap-2 flex-shrink-0 border-t border-slate-700 pt-4">
         <Button
           variant="outline"
           onClick={allSubmitted && onClose ? onClose : onPrevious}


### PR DESCRIPTION
## What changed

Refactored the layout structure of the `MultipleTransactionsReview` component (Step 2 of the bulk transaction modal) to prevent layout shifting and improve scrolling behavior:
- Converted the main layout container from a stacking layout (`space-y-6`) to a structured flex layout (`flex flex-col gap-6`) to cleanly bind structural sections to the viewport.
- Confined the transaction cards preview list to an independent scrollable pane with explicit height constraints (`overflow-y-auto max-h-[55vh] -mx-2 px-2`) to keep overflow tidy without clipping the borders.
- Re-architected the dialog action footer as a rigid structural block (`flex-shrink-0`) and moved the standalone structural divider line directly into the footer's upper border rule (`border-t border-slate-700 pt-4`).

## Why

Fixes a critical layout issue where long transaction imports caused the action footer (containing the submission buttons) to push past the viewport bounds, forcing users to scroll past all items to submit or cancel. These changes freeze the viewport footprint so the list scrolls natively inside its own container while the confirmation buttons stay locked into position at the base of the dialog.

Closes # [5]

## Testing

Verified visual responsiveness and structural positioning locally:
- Pasted a broad mock dataset (spanning 15+ complex concurrent transactions) into the Step 1 input area.
- Confirmed that the step 2 view handles the long list smoothly, with the transaction cards wrapping independently while the confirmation footer remains strictly visible at the bottom.
- Validated on both desktop layout bounds (`Dialog`) and simulated mobile screen scopes (`Drawer`).
- Ran local static analysis checks to guarantee no regression patterns were introduced to Step 1 (`MultipleTransactionsInput`).

## Screenshots 
<img width="812" height="841" alt="image" src="https://github.com/user-attachments/assets/844dfd6c-6843-4a2f-b0c8-be6fcbe6937d" />


## Checklist

- [x] PR targets `develop` (not `main`)
- [ ] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint:types` pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout spacing and scrolling functionality for the transaction review interface, improving visual organization and usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wajahat43/psxworth/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->