### PR TITLE
fix: enhance display of number of shares in transaction summary

### DIFF
--- a/src/components/molecules/TransactionPreviewCard/TransactionSummary.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionSummary.tsx
@@ -26,6 +26,19 @@ const displayValue = (fieldName: string, value: any, formatter?: (value: any) =>
   return <>{formatter ? formatter(value) : String(value)}</>;
 };
 
+const displaySharesValue = (value: unknown) => {
+  if (value === undefined || value === null || value === "") {
+    return <span className="text-red-500">MISSING Number of Shares</span>;
+  }
+
+  const sharesValue = Number(value);
+  if (!Number.isFinite(sharesValue) || sharesValue <= 0) {
+    return <span className="text-red-500">{String(value)}</span>;
+  }
+
+  return <>{String(value)}</>;
+};
+
 interface TransactionSummaryProps {
   transaction: TransactionSchemaType;
 }
@@ -58,7 +71,7 @@ export const TransactionSummary: React.FC<TransactionSummaryProps> = ({ transact
     const totalValue = pricePerShare * numberOfShares + totalCommission;
     return (
       <p className="text-sm text-muted-foreground mt-2">
-        Buy {displayValue("Number of Shares", numberOfShares)} shares of {displayStockSymbol(stockSymbol)} at{" "}
+        Buy {displaySharesValue(numberOfShares)} shares of {displayStockSymbol(stockSymbol)} at{" "}
         {displayValue("Price per Share", pricePerShare, formatCurrency)} with{" "}
         {isCommissionPercentage && commissionAndTaxes
           ? formatPercentage(commissionAndTaxes)
@@ -71,7 +84,7 @@ export const TransactionSummary: React.FC<TransactionSummaryProps> = ({ transact
     const totalValue = pricePerShare * numberOfShares - totalCommission;
     return (
       <p className="text-sm text-muted-foreground mt-2">
-        Sell {displayValue("Number of Shares", numberOfShares)} shares of {displayStockSymbol(stockSymbol)}
+        Sell {displaySharesValue(numberOfShares)} shares of {displayStockSymbol(stockSymbol)}
         {pricePerShare ? <> at {displayValue("Price per Share", pricePerShare, formatCurrency)}</> : ""} with{" "}
         {isCommissionPercentage && commissionAndTaxes
           ? formatPercentage(commissionAndTaxes)
@@ -86,7 +99,11 @@ export const TransactionSummary: React.FC<TransactionSummaryProps> = ({ transact
       <p className="text-sm text-muted-foreground mt-2">
         Received {displayValue("Dividend per Share", dividendPerShare, formatCurrency)} dividend per share for{" "}
         {displayStockSymbol(stockSymbol)}
-        {numberOfShares ? <> ({displayValue("Number of Shares", numberOfShares)} shares)</> : ""} with{" "}
+        {numberOfShares !== undefined && numberOfShares !== null ? (
+          <> ({displaySharesValue(numberOfShares)} shares)</>
+        ) : (
+          ""
+        )} with{" "}
         {isCommissionPercentage && commissionAndTaxes
           ? formatPercentage(commissionAndTaxes)
           : formatCurrency(totalCommission)}{" "}

--- a/src/components/molecules/TransactionPreviewCard/TransactionSummary.tsx
+++ b/src/components/molecules/TransactionPreviewCard/TransactionSummary.tsx
@@ -99,7 +99,7 @@ export const TransactionSummary: React.FC<TransactionSummaryProps> = ({ transact
       <p className="text-sm text-muted-foreground mt-2">
         Received {displayValue("Dividend per Share", dividendPerShare, formatCurrency)} dividend per share for{" "}
         {displayStockSymbol(stockSymbol)}
-        {numberOfShares !== undefined && numberOfShares !== null ? (
+        {numberOfShares !== undefined && numberOfShares !== null && String(numberOfShares).trim() !== "" ? (
           <> ({displaySharesValue(numberOfShares)} shares)</>
         ) : (
           ""


### PR DESCRIPTION
# What changed
Updated the import transaction summary card so 0, negative, or otherwise invalid share counts are shown in red directly in the collapsed review view.

# Why
This fixes a UX gap in the import flow where invalid shares were blocking submission, but the error was only visible after expanding Edit.

**Closes** #25 

## Screenshots

https://github.com/user-attachments/assets/7f7a8163-c921-4b64-b7c7-04451b62de19

## Checklist

- [x] PR targets `develop` (not `main`)
- [x] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint:types` pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error messaging for share counts in transaction preview cards: missing values now show a clear red "MISSING Number of Shares" indicator and invalid or non-finite inputs are highlighted.
  * Made share-count display consistent across buy, sell, and dividend summaries; dividend entries now show the share-count parenthetical when a count is provided (including zero), rather than relying on truthiness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wajahat43/psxworth/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->