### PR TITLE
Implement LoadingGradientButton and DotFlow components with state management

### DIFF
--- a/src/components/molecules/MultipleTransactionsInput/MultipleTransactionsInput.tsx
+++ b/src/components/molecules/MultipleTransactionsInput/MultipleTransactionsInput.tsx
@@ -1,6 +1,5 @@
 import { FloatingLabelTextarea } from "@/components/ui/floating-label-textarea";
-import GradientButton from "@/components/ui/gradient-button";
-import SpinningLoader from "@/components/ui/spinning-loader";
+import { LoadingGradientButton } from "@/components/ui/loading-gradient-button";
 import { Zap, ShieldCheck } from "lucide-react";
 import React, { useState } from "react";
 
@@ -68,21 +67,23 @@ Dividend received: Rs. 25/share on 300 shares of PSO, total: Rs. 7,500 (no fees)
           </div>
         </div>
 
-        <GradientButton
+        <LoadingGradientButton
           type="submit"
-          disabled={!inputData.trim() || isLoading}
+          disabled={!inputData.trim()}
+          isLoading={isLoading}
           variant="cyanBlue"
           fullWidth
           className="shadow-lg shadow-cyan-500/10"
+          loadingMessages={[
+            "Reading your broker paste",
+            "Finding buys, sells & dividends",
+            "Matching PSX tickers",
+            "Pulling dates, prices & fees",
+            "Polishing the results",
+          ]}
         >
-          {isLoading ? (
-            <div className="flex gap-2 items-center">
-              <SpinningLoader size="xxs" /> Analyzing...
-            </div>
-          ) : (
-            "Process Data"
-          )}
-        </GradientButton>
+          Process Data
+        </LoadingGradientButton>
       </div>
     </form>
   );

--- a/src/components/ui/dot-flow.tsx
+++ b/src/components/ui/dot-flow.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { motion } from "motion/react";
+
+const PARTICLES = [
+  { delay: 0, duration: 2.0, yOffset: 0, scale: 1.0, blur: 8 },
+  { delay: 0.3, duration: 2.2, yOffset: 0, scale: 0.9, blur: 7 },
+  { delay: 0.6, duration: 1.9, yOffset: 0, scale: 0.85, blur: 6 },
+
+  { delay: 0.15, duration: 2.4, yOffset: -8, scale: 0.7, blur: 5 },
+  { delay: 0.8, duration: 2.1, yOffset: -8, scale: 0.65, blur: 4 },
+
+  { delay: 0.45, duration: 2.3, yOffset: 8, scale: 0.75, blur: 5 },
+  { delay: 1.0, duration: 2.0, yOffset: 8, scale: 0.7, blur: 4 },
+];
+
+const GLOW_PULSES = [
+  { delay: 0, duration: 2.5, spread: 16 },
+  { delay: 0.8, duration: 3.2, spread: 24 },
+  { delay: 1.6, duration: 2.8, spread: 20 },
+];
+
+export function DotFlow({ className }: { className?: string }) {
+  return (
+    <span className={cn("relative inline-flex h-6 w-16 items-center justify-center", className)} aria-hidden>
+      {GLOW_PULSES.map((pulse, i) => (
+        <motion.span
+          key={`glow-${i}`}
+          className="pointer-events-none absolute inset-0 rounded-full bg-cyan-500/10"
+          animate={{
+            scale: [0.8, 1.2, 0.8],
+            opacity: [0.3, 0.6, 0.3],
+          }}
+          transition={{
+            duration: pulse.duration,
+            delay: pulse.delay,
+            repeat: Infinity,
+            ease: "easeInOut",
+          }}
+          style={{
+            filter: `blur(${pulse.spread}px)`,
+          }}
+        />
+      ))}
+
+      <motion.span
+        className="absolute inset-x-2 inset-y-2 rounded-full bg-gradient-to-r from-transparent via-cyan-400/5 to-transparent"
+        animate={{
+          x: [-20, 20, -20],
+        }}
+        transition={{
+          duration: 3,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+      />
+
+      {PARTICLES.map((particle, i) => (
+        <motion.span
+          key={`particle-${i}`}
+          className="absolute rounded-full bg-cyan-400"
+          style={{
+            width: particle.scale * 8,
+            height: particle.scale * 8,
+            filter: `blur(${particle.blur}px)`,
+            boxShadow: `0 0 ${particle.blur * 2}px rgba(34,211,238,0.7)`,
+          }}
+          animate={{
+            x: [-28, 28],
+            y: [particle.yOffset, particle.yOffset + Math.sin(i) * 2],
+            opacity: [0, 0.4, 1, 0.4, 0],
+            scale: [0.5, particle.scale, particle.scale, particle.scale, 0.5],
+          }}
+          transition={{
+            duration: particle.duration,
+            delay: particle.delay,
+            repeat: Infinity,
+            ease: "easeInOut",
+          }}
+        />
+      ))}
+
+      {[...Array(4)].map((_, i) => (
+        <motion.span
+          key={`micro-${i}`}
+          className="absolute w-1 h-1 rounded-full bg-blue-300/60"
+          animate={{
+            x: [-24, 24],
+            y: [Math.sin(i * 2) * 6, Math.cos(i * 2) * 6],
+            opacity: [0, 0.6, 0],
+          }}
+          transition={{
+            duration: 1.8 + i * 0.3,
+            delay: i * 0.5,
+            repeat: Infinity,
+            ease: "linear",
+          }}
+        />
+      ))}
+
+      <motion.span
+        className="absolute w-2 h-2 rounded-full bg-cyan-300"
+        animate={{
+          scale: [0.8, 1.2, 0.8],
+          opacity: [0.6, 1, 0.6],
+        }}
+        transition={{
+          duration: 1.5,
+          repeat: Infinity,
+          ease: "easeInOut",
+        }}
+        style={{
+          boxShadow: "0 0 12px rgba(34,211,238,0.9)",
+        }}
+      />
+    </span>
+  );
+}

--- a/src/components/ui/gradient-button.tsx
+++ b/src/components/ui/gradient-button.tsx
@@ -105,7 +105,7 @@ const spanVariants = cva(
   }
 );
 
-interface GradientButtonProps
+export interface GradientButtonProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "disabled">,
     VariantProps<typeof gradientButtonVariants> {
   children: React.ReactNode;

--- a/src/components/ui/loading-gradient-button.tsx
+++ b/src/components/ui/loading-gradient-button.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { DotFlow } from "@/components/ui/dot-flow";
-import GradientButton, { type GradientButtonProps } from "@/components/ui/gradient-button";
+import GradientButton, {
+  type GradientButtonProps,
+} from "@/components/ui/gradient-button";
 import { cn } from "@/lib/utils";
 import { AnimatePresence, motion } from "motion/react";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 const DEFAULT_LOADING_MESSAGES = [
   "Reading your paste",
@@ -16,10 +18,10 @@ const DEFAULT_LOADING_MESSAGES = [
 
 const MESSAGE_INTERVAL_MS = 3200;
 
-export interface LoadingGradientButtonProps extends GradientButtonProps {
+export interface LoadingGradientButtonProps
+  extends GradientButtonProps {
   isLoading?: boolean;
   loadingLabel?: string;
-
   loadingMessages?: string[];
 }
 
@@ -33,38 +35,37 @@ export function LoadingGradientButton({
   ...props
 }: LoadingGradientButtonProps) {
   const isDisabled = disabled || isLoading;
-  const messages = loadingLabel ? [loadingLabel, ...loadingMessages] : loadingMessages;
+
+  const messages = loadingLabel
+    ? [loadingLabel, ...loadingMessages]
+    : loadingMessages;
+
   const [messageIndex, setMessageIndex] = useState(0);
-  const prevIsLoadingRef = useRef(isLoading);
 
   useEffect(() => {
-    const wasLoading = prevIsLoadingRef.current;
-    prevIsLoadingRef.current = isLoading;
-
-    if (wasLoading && !isLoading) {
-      setMessageIndex(0);
-      return;
-    }
-
-    if (!isLoading) {
-      return;
-    }
+    if (!isLoading) return;
 
     const intervalId = window.setInterval(() => {
-      setMessageIndex((current) => (current + 1) % messages.length);
+      setMessageIndex(
+        (current) => (current + 1) % messages.length,
+      );
     }, MESSAGE_INTERVAL_MS);
 
     return () => window.clearInterval(intervalId);
   }, [isLoading, messages.length]);
 
-  const activeMessage = messages[messageIndex] ?? messages[0];
+  const activeMessage =
+    messages[messageIndex] ?? messages[0];
 
   return (
     <GradientButton
       disabled={isDisabled}
       aria-busy={isLoading}
       aria-live={isLoading ? "polite" : undefined}
-      className={cn(isLoading && "shadow-lg shadow-cyan-500/20", className)}
+      className={cn(
+        isLoading && "shadow-lg shadow-cyan-500/20",
+        className,
+      )}
       {...props}
     >
       {isLoading ? (
@@ -72,20 +73,29 @@ export function LoadingGradientButton({
           <motion.span
             className="pointer-events-none absolute inset-0 rounded-md bg-gradient-to-r from-cyan-500/0 via-cyan-400/10 to-cyan-500/0"
             animate={{ x: ["-120%", "120%"] }}
-            transition={{ duration: 2.2, repeat: Infinity, ease: "linear" }}
+            transition={{
+              duration: 2.2,
+              repeat: Infinity,
+              ease: "linear",
+            }}
           />
+
           <AnimatePresence mode="wait">
             <motion.span
               key={activeMessage}
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -6 }}
-              transition={{ duration: 0.25, ease: "easeOut" }}
+              transition={{
+                duration: 0.25,
+                ease: "easeOut",
+              }}
               className="relative z-10 max-w-[14rem] text-center text-sm font-medium leading-snug text-slate-100 sm:max-w-none sm:text-left"
             >
               {activeMessage}
             </motion.span>
           </AnimatePresence>
+
           <DotFlow className="relative z-10 shrink-0" />
         </span>
       ) : (

--- a/src/components/ui/loading-gradient-button.tsx
+++ b/src/components/ui/loading-gradient-button.tsx
@@ -4,7 +4,7 @@ import { DotFlow } from "@/components/ui/dot-flow";
 import GradientButton, { type GradientButtonProps } from "@/components/ui/gradient-button";
 import { cn } from "@/lib/utils";
 import { AnimatePresence, motion } from "motion/react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 const DEFAULT_LOADING_MESSAGES = [
   "Reading your paste",
@@ -35,10 +35,18 @@ export function LoadingGradientButton({
   const isDisabled = disabled || isLoading;
   const messages = loadingLabel ? [loadingLabel, ...loadingMessages] : loadingMessages;
   const [messageIndex, setMessageIndex] = useState(0);
+  const prevIsLoadingRef = useRef(isLoading);
 
   useEffect(() => {
-    if (!isLoading) {
+    const wasLoading = prevIsLoadingRef.current;
+    prevIsLoadingRef.current = isLoading;
+
+    if (wasLoading && !isLoading) {
       setMessageIndex(0);
+      return;
+    }
+
+    if (!isLoading) {
       return;
     }
 

--- a/src/components/ui/loading-gradient-button.tsx
+++ b/src/components/ui/loading-gradient-button.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { DotFlow } from "@/components/ui/dot-flow";
+import GradientButton, { type GradientButtonProps } from "@/components/ui/gradient-button";
+import { cn } from "@/lib/utils";
+import { AnimatePresence, motion } from "motion/react";
+import React, { useEffect, useState } from "react";
+
+const DEFAULT_LOADING_MESSAGES = [
+  "Reading your paste",
+  "Spotting buy & sell lines",
+  "Matching PSX symbols",
+  "Extracting dates & amounts",
+  "Almost there",
+];
+
+const MESSAGE_INTERVAL_MS = 3200;
+
+export interface LoadingGradientButtonProps extends GradientButtonProps {
+  isLoading?: boolean;
+  loadingLabel?: string;
+
+  loadingMessages?: string[];
+}
+
+export function LoadingGradientButton({
+  children,
+  isLoading = false,
+  loadingLabel,
+  loadingMessages = DEFAULT_LOADING_MESSAGES,
+  disabled = false,
+  className,
+  ...props
+}: LoadingGradientButtonProps) {
+  const isDisabled = disabled || isLoading;
+  const messages = loadingLabel ? [loadingLabel, ...loadingMessages] : loadingMessages;
+  const [messageIndex, setMessageIndex] = useState(0);
+
+  useEffect(() => {
+    if (!isLoading) {
+      setMessageIndex(0);
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      setMessageIndex((current) => (current + 1) % messages.length);
+    }, MESSAGE_INTERVAL_MS);
+
+    return () => window.clearInterval(intervalId);
+  }, [isLoading, messages.length]);
+
+  const activeMessage = messages[messageIndex] ?? messages[0];
+
+  return (
+    <GradientButton
+      disabled={isDisabled}
+      aria-busy={isLoading}
+      aria-live={isLoading ? "polite" : undefined}
+      className={cn(isLoading && "shadow-lg shadow-cyan-500/20", className)}
+      {...props}
+    >
+      {isLoading ? (
+        <span className="relative flex w-full min-h-[1.5rem] flex-col items-center justify-center gap-2 py-0.5 sm:flex-row sm:gap-3">
+          <motion.span
+            className="pointer-events-none absolute inset-0 rounded-md bg-gradient-to-r from-cyan-500/0 via-cyan-400/10 to-cyan-500/0"
+            animate={{ x: ["-120%", "120%"] }}
+            transition={{ duration: 2.2, repeat: Infinity, ease: "linear" }}
+          />
+          <AnimatePresence mode="wait">
+            <motion.span
+              key={activeMessage}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={{ duration: 0.25, ease: "easeOut" }}
+              className="relative z-10 max-w-[14rem] text-center text-sm font-medium leading-snug text-slate-100 sm:max-w-none sm:text-left"
+            >
+              {activeMessage}
+            </motion.span>
+          </AnimatePresence>
+          <DotFlow className="relative z-10 shrink-0" />
+        </span>
+      ) : (
+        children
+      )}
+    </GradientButton>
+  );
+}


### PR DESCRIPTION
## What changed

This PR improves the loading experience in the Import Transactions flow by replacing the static spinner with a modern **dot-flow animated loader**.

### Changes included:
- Added reusable `dot-flow.tsx` animation component (Framer Motion)
- Introduced `loading-gradient-button.tsx` to extend `GradientButton` with enhanced loading UX
- Integrated new loading button into `MultipleTransactionsInput.tsx` for “Process Data”
- Added animated dot-flow + rotating loading messages during AI processing

## Why

The previous loading state used a simple spinner with static text (“Analyzing…”), which was not engaging for longer AI processing tasks.

This update improves UX by:
- Making loading states more engaging and dynamic
- Providing contextual feedback during processing
- Reducing perceived waiting time
- Improving overall interaction quality

Closes #6 

## Testing

- Verified in `pnpm dev`
- Tested transaction import flow end-to-end
- Confirmed:
  - Dot-flow animation works smoothly
  - Loading messages rotate correctly
  - Button disables properly during loading
  - No UI or console errors
  - Mobile + desktop responsive behavior

## Screenshots / video (UI changes only)

https://github.com/user-attachments/assets/e890b8fe-522d-4310-a991-fd8289bdda6b

## Checklist

- [x] PR targets `develop`
- [x] Assigned to issue
- [x] `pnpm lint` & `pnpm lint:types` pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced loading experience during data processing: animated shimmer, cycling status messages, and a stable "Process Data" label for clearer feedback.
  * Decorative animated particle flow added to loading states for improved visual polish.
  * Submit button behavior refined so loading indicators and enabled/disabled feedback are more consistent during processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Wajahat43/psxworth/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->