### PR TITLE
feat: implement server-side pagination, filtering, and sorting for th…

### DIFF
--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -112,7 +112,7 @@ const getTransactionsUncached = async (
   portfolioId: number,
   page: number = 1,
   pageSize: number = 20,
-  filters?: { types?: ("buy" | "sell" | "dividend")[], symbols?: string[] },
+  filters?: { types?: string[], symbols?: string[] },
   sorting?: { key: string; order: string } | null
 ) => {
   await withPortfolioOwnership(portfolioId, userId);
@@ -120,7 +120,7 @@ const getTransactionsUncached = async (
 
   const whereClause = and(
     eq(transactionTable.portfolioId, portfolioId),
-    filters?.types && filters.types.length > 0 ? inArray(transactionTable.type, filters.types) : undefined,
+    filters?.types && filters.types.length > 0 ? inArray(transactionTable.type, filters.types as ("buy" | "sell" | "dividend")[] ) : undefined,
     filters?.symbols && filters.symbols.length > 0 ? inArray(transactionTable.stockSymbol, filters.symbols) : undefined,
   );
 
@@ -173,7 +173,7 @@ export const getTransactions = withErrorHandling(
     portfolioId: number,
     page: number = 1,
     pageSize: number = 10,
-    filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+    filters?: { types?: string[]; symbols?: string[] },
     sorting?: { key: string; order: string } | null
   ) => {
     page = Math.max(1, page ?? 1);

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -138,8 +138,8 @@ const getTransactionsUncached = async (
   const orderByClause =
     sortColumn
       ? sorting?.order === "desc"
-        ? [desc(sortColumn)]
-        : [asc(sortColumn)]
+        ? [desc(sortColumn),asc(transactionTable.id)]
+        : [asc(sortColumn),asc(transactionTable.id)]
       : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
 
   const [transactions, totalCountResult,availableSymbols] = await Promise.all([
@@ -172,7 +172,7 @@ export const getTransactions = withErrorHandling(
   async (
     portfolioId: number,
     page: number = 1,
-    pageSize: number = 20,
+    pageSize: number = 10,
     filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
     sorting?: { key: string; order: string } | null
   ) => {

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -131,7 +131,7 @@ const getTransactionsUncached = async (
         : [asc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
       : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
 
-  const [transactions, totalCountResult] = await Promise.all([
+  const [transactions, totalCountResult,availableSymbols] = await Promise.all([
     db
       .select()
       .from(transactionTable)
@@ -143,11 +143,17 @@ const getTransactionsUncached = async (
       .select({ count: count() })
       .from(transactionTable)
       .where(whereClause),
+  db
+  .selectDistinct({ stockSymbol: transactionTable.stockSymbol })
+  .from(transactionTable)
+  .where(eq(transactionTable.portfolioId, portfolioId))
+
   ]);
 
   return {
     items: transactions,
     totalCount: Number(totalCountResult[0].count),
+    availableSymbols
   };
 };
 
@@ -184,7 +190,8 @@ export const getTransactions = withErrorHandling(
       totalCount: result.totalCount,
       page,
       pageSize,
-      totalPages: Math.ceil(result.totalCount / pageSize)
+      totalPages: Math.ceil(result.totalCount / pageSize),
+      availableSymbols:result.availableSymbols
     };
   }
 );

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -159,7 +159,10 @@ export const getTransactions = withErrorHandling(
     filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
     sorting?: { key: string; order: string } | null
   ) => {
-    
+    page = Math.max(1, page ?? 1);
+    pageSize = [10, 20, 40, 50].includes(pageSize)
+      ? pageSize
+      : 10;
 
     const userId = await requireAuth();
     await withPortfolioOwnership(portfolioId, userId);

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -124,11 +124,22 @@ const getTransactionsUncached = async (
     filters?.symbols && filters.symbols.length > 0 ? inArray(transactionTable.stockSymbol, filters.symbols) : undefined,
   );
 
+  const sortableColumns = {
+    transactionDate: transactionTable.transactionDate,
+    type: transactionTable.type,
+    stockSymbol: transactionTable.stockSymbol,
+    numberOfShares: transactionTable.numberOfShares,
+    pricePerShare: transactionTable.pricePerShare,
+    commissionAndTaxes: transactionTable.commissionAndTaxes,
+  } as const;
+
+  const sortColumn = sorting?.key ? sortableColumns[sorting.key as keyof typeof sortableColumns] : undefined;
+
   const orderByClause =
-    sorting?.key && sorting.key in transactionTable
-      ? sorting.order === "desc"
-        ? [desc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
-        : [asc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
+    sortColumn
+      ? sorting?.order === "desc"
+        ? [desc(sortColumn)]
+        : [asc(sortColumn)]
       : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
 
   const [transactions, totalCountResult,availableSymbols] = await Promise.all([

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -15,7 +15,7 @@ import { Transaction, TransactionSchemaType } from "@/types";
 import { MULTIPLE_TRANSACTIONS_CREATED, TRANSACTION_CREATED, TRANSACTION_DELETED } from "@/utils/posthog/events";
 import { generateObject } from "ai";
 import "dotenv/config";
-import { asc, eq } from "drizzle-orm";
+import { asc, desc, eq, and, inArray, count } from "drizzle-orm";
 import { unstable_cache, updateTag } from "next/cache";
 import { createResponse } from "../utils";
 import { requireAuth, withPortfolioOwnership, withErrorHandling } from "../utils/middleware";
@@ -107,34 +107,84 @@ export const parseRawTransactions = withErrorHandling(async (rawTransactions: st
   throw new Error("Transactions Couldn't be parsed properly. Please check if your data is valid.");
 });
 
-const getTransactionsUncached = async (userId: string, portfolioId: number) => {
+const getTransactionsUncached = async (
+  userId: string,
+  portfolioId: number,
+  page: number = 1,
+  pageSize: number = 20,
+  filters?: { types?: ("buy" | "sell" | "dividend")[], symbols?: string[] },
+  sorting?: { key: string; order: string } | null
+) => {
   await withPortfolioOwnership(portfolioId, userId);
-  const transactions = await db
-    .select()
-    .from(transactionTable)
-    .where(eq(transactionTable.portfolioId, portfolioId))
-    .orderBy(asc(transactionTable.transactionDate), asc(transactionTable.type));
+  const offset = Math.max(0, (page - 1) * pageSize);
 
-  return transactions;
+  const whereClause = and(
+    eq(transactionTable.portfolioId, portfolioId),
+    filters?.types && filters.types.length > 0 ? inArray(transactionTable.type, filters.types) : undefined,
+    filters?.symbols && filters.symbols.length > 0 ? inArray(transactionTable.stockSymbol, filters.symbols) : undefined,
+  );
+
+  const orderByClause =
+    sorting?.key && sorting.key in transactionTable
+      ? sorting.order === "desc"
+        ? [desc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
+        : [asc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
+      : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
+
+  const [transactions, totalCountResult] = await Promise.all([
+    db
+      .select()
+      .from(transactionTable)
+      .where(whereClause)
+      .orderBy(...orderByClause)
+      .limit(pageSize)
+      .offset(offset),
+    db
+      .select({ count: count() })
+      .from(transactionTable)
+      .where(whereClause),
+  ]);
+
+  return {
+    items: transactions,
+    totalCount: Number(totalCountResult[0].count),
+  };
 };
 
-export const getTransactions = withErrorHandling(async (portfolioId: number) => {
-  const userId = await requireAuth();
-  await withPortfolioOwnership(portfolioId, userId);
+export const getTransactions = withErrorHandling(
+  async (
+    portfolioId: number,
+    page: number = 1,
+    pageSize: number = 20,
+    filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+    sorting?: { key: string; order: string } | null
+  ) => {
+    
 
-  const transactions = await unstable_cache(
-    async () => {
-      return await getTransactionsUncached(userId, portfolioId);
-    },
-    [`${userId}-${portfolioId}-transactions`],
-    {
-      tags: [`${userId}-${portfolioId}-transactions`],
-      revalidate: 60 * 60, //Revalidate after 1 hour.
-    }
-  )();
+    const userId = await requireAuth();
+    await withPortfolioOwnership(portfolioId, userId);
+    const filterKey = JSON.stringify(filters || {});
+    const sortKey = JSON.stringify(sorting || {});
+    const result = await unstable_cache(
+      async () => {
+        return await getTransactionsUncached(userId, portfolioId, page, pageSize, filters, sorting);
+      },
+      [`${userId}-${portfolioId}-transactions-page-${page}-size-${pageSize}-filters-${filterKey}-sorting-${sortKey}`],
+      {
+        tags: [`${userId}-${portfolioId}-transactions`],
+        revalidate: 60 * 60, //Revalidate after 1 hour.
+      }
+    )();
 
-  return transactions;
-});
+    return {
+      items: result.items,
+      totalCount: result.totalCount,
+      page,
+      pageSize,
+      totalPages: Math.ceil(result.totalCount / pageSize)
+    };
+  }
+);
 
 export const editTransaction = withErrorHandling(
   async (transactionId: number, updatedTransactionData: TransactionSchemaType) => {

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -33,7 +33,7 @@ import { Button } from "@/components/ui/button";
 const MotionTableRow = motion.create(TableRow);
 
 interface TransactionFilters {
-  types?: ("buy" | "sell" | "dividend")[];
+  types?: string[];
   symbols?: string[];
 }
 
@@ -53,12 +53,12 @@ interface DataTableProps<TData, TValue> {
   onToggleView?: (fullTable: boolean) => void;
   renderMobileSubRow?: (original: TData) => React.ReactNode;
   pageState: pageState;
-  setPageState: (value: pageState) => void;
+  setPageState: React.Dispatch<React.SetStateAction<pageState>>;
   totalPages: number;
   filters: TransactionFilters;
-  setFilters: (value: TransactionFilters) => void;
+  setFilters:  React.Dispatch<React.SetStateAction<TransactionFilters>>;
   sorting: { key: string, order: "asc" | "desc" } | null;
-  setSorting: (value: { key: string, order: "asc" | "desc" } | null) => void
+  setSorting: React.Dispatch<React.SetStateAction<{ key: string, order: "asc" | "desc" } | null>>;
   availableSymbols: { stockSymbol: string }[]
 
 }
@@ -74,7 +74,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   "use no memo";
 
 
-  const { availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
+  const { availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props 
 
 
   /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table's useReactTable() returns functions that cannot be memoized safely */
@@ -94,13 +94,13 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
 
   const handleNext = () => {
     if (pageState?.page < totalPages) {
-      setPageState((prev: any) => ({ ...prev, page: prev.page + 1 }));
+      setPageState((prev) => ({ ...prev, page: prev.page + 1 }));
     }
   };
 
   const handlePrev = () => {
     if (pageState?.page > 1) {
-      setPageState((prev: any) => ({ ...prev, page: prev.page - 1 }));
+      setPageState((prev) => ({ ...prev, page: prev.page - 1 }));
     }
   };
 
@@ -117,9 +117,9 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
             <DataTableFilters
               data={data as Transaction[]}
               availableSymbols={availableSymbols?.map((val: { stockSymbol: string }) => val.stockSymbol)}
-              onFilterChange={(newFilters: any) => {
+              onFilterChange={(newFilters) => {
                 setFilters(newFilters);
-                setPageState((prev: any) => ({ ...prev, page: 1 }));
+                setPageState((prev) => ({ ...prev, page: 1 }));
               }} activeFilters={filters} />
             {shouldShowMobileLayout !== undefined && onToggleView ? (
               <TableViewToggle
@@ -146,11 +146,11 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
                   return (
                     <TableHead key={header.id}
                       onClick={header.column.getCanSort() ? () => {
-                        setPageState((prev: any) => ({ ...prev, page: 1 }));
+                        setPageState((prev) => ({ ...prev, page: 1 }));
                         if (sorting == null) {
                           setSorting({ key: header.column.id, order: "asc" })
                         } else if (sorting?.key === header.column.id) {
-                          setSorting((prev: any) => ({ key: header.column.id, order: prev.order === "desc" ? "asc" : "desc" }))
+                          setSorting((prev) => ({ key: header.column.id, order: prev?.order === "desc" ? "asc" : "desc" }))
                         } else {
                           setSorting({ key: header.column.id, order: "asc" })
                         }

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -1,20 +1,26 @@
 "use client";
 
+
+
+import {
+  Select,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+
 import { ExportTransactionsButton } from "@/components/molecules/ExportTransactionsButton";
 import { TableToggleColumns } from "@/components/ui/TableToggleColumns";
 import { CustomTableRow, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { Transaction } from "@/types";
 import {
-  FilterFn,
   ColumnDef,
   flexRender,
-  SortingState,
   useReactTable,
   getCoreRowModel,
-  getSortedRowModel,
   getExpandedRowModel,
-  getFilteredRowModel,
 } from "@tanstack/react-table";
 import { Loader2 } from "lucide-react";
 import { motion, AnimatePresence, MotionConfig } from "motion/react";
@@ -22,8 +28,14 @@ import React from "react";
 import { TableViewToggle } from "../../TableViewToggle";
 import { TransactionDetailCard } from "../TransactionDetailCard";
 import { DataTableFilters } from "./DataTableFilters";
+import { Button } from "@/components/ui/button";
 
 const MotionTableRow = motion.create(TableRow);
+
+interface TransactionFilters {
+  types?: ("buy" | "sell" | "dividend")[];
+  symbols?: string[];
+}
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -31,14 +43,16 @@ interface DataTableProps<TData, TValue> {
   isLoading?: boolean;
   shouldShowMobileLayout?: boolean;
   onToggleView?: (fullTable: boolean) => void;
-  /** Renders a full-width row below each row when in mobile layout (e.g. "Since transaction") */
   renderMobileSubRow?: (original: TData) => React.ReactNode;
+  pageState: any;
+  setPageState?: any;
+  totalPages?: number;
+  filters?: TransactionFilters;
+  setFilters?: any;
+  sorting?: { key: string; order: string } | null;
+  setSorting?: any;
 }
 
-interface TransactionFilters {
-  types?: string[];
-  symbols?: string[];
-}
 
 const transition = {
   type: "spring",
@@ -48,49 +62,37 @@ const transition = {
 
 export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   "use no memo";
-  const { columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props;
-  const [sorting, setSorting] = React.useState<SortingState>([{ id: "transactionDate", desc: true }]);
-  const [filters, setFilters] = React.useState<TransactionFilters>({});
 
-  const transactionFilterFn: FilterFn<TData> = (row, columnId, filterValue: TransactionFilters) => {
-    const transaction = row.original as Transaction;
 
-    // Apply type filter
-    if (filterValue.types && filterValue.types.length > 0) {
-      if (!filterValue.types.includes(transaction.type)) {
-        return false;
-      }
-    }
+  const { sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
 
-    // Apply symbol filter
-    if (filterValue.symbols && filterValue.symbols.length > 0) {
-      if (!filterValue.symbols.includes(transaction.stockSymbol)) {
-        return false;
-      }
-    }
-
-    return true;
-  };
 
   /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table's useReactTable() returns functions that cannot be memoized safely */
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    onSortingChange: setSorting,
-    getSortedRowModel: getSortedRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    filterFns: {
-      transactionFilter: transactionFilterFn,
-    },
-    globalFilterFn: transactionFilterFn,
-    state: {
-      sorting,
-      globalFilter: filters,
-    },
-    onGlobalFilterChange: setFilters,
+
+
   });
+
+
+  const handlePageSize = (value: string) => {
+    setPageState({ page: 1, pageSize: Number(value) });
+  };
+
+  const handleNext = () => {
+    if (pageState?.page < totalPages) {
+      setPageState((prev: any) => ({ ...prev, page: prev.page + 1 }));
+    }
+  };
+
+  const handlePrev = () => {
+    if (pageState?.page > 1) {
+      setPageState((prev: any) => ({ ...prev, page: prev.page - 1 }));
+    }
+  };
 
   // Get current view transactions (filtered data)
   const currentViewTransactions = isLoading
@@ -102,7 +104,10 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       <div className="flex h-full min-h-0 flex-col rounded-lg border border-slate-700">
         <div className="shrink-0 rounded-t-lg border-b border-slate-700 bg-slate-800 px-2 py-2">
           <div className="flex flex-wrap items-center justify-start md:justify-end gap-2 w-full md:w-auto">
-            <DataTableFilters data={data as Transaction[]} onFilterChange={setFilters} activeFilters={filters} />
+            <DataTableFilters data={data as Transaction[]} onFilterChange={(newFilters: any) => {
+              setFilters(newFilters);
+              setPageState((prev: any) => ({ ...prev, page: 1 }));
+            }} activeFilters={filters} />
             {shouldShowMobileLayout !== undefined && onToggleView ? (
               <TableViewToggle
                 shouldShowMobileLayout={shouldShowMobileLayout}
@@ -126,7 +131,18 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id} className="sticky top-0 z-10 bg-slate-800 text-gray-100/90">
+                    <TableHead key={header.id}
+                      onClick={header.column.getCanSort() ? () => {
+                        setPageState((prev: any) => ({ ...prev, page: 1 }));
+                        if (sorting == null) {
+                          setSorting({ key: header.column.id, order: "asc" })
+                        } else if (sorting?.key === header.column.id) {
+                          setSorting((prev: any) => ({ key: header.column.id, order: prev.order === "desc" ? "asc" : "desc" }))
+                        } else {
+                          setSorting({ key: header.column.id, order: "asc" })
+                        }
+                      } : undefined}
+                      className="sticky top-0 z-10 bg-slate-800 text-gray-100/90">
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
                   );
@@ -195,6 +211,33 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
             )}
           </TableBody>
         </Table>
+        <div className="bg-slate-800  flex justify-between p-4">
+
+          <div className="">
+            <Select
+              value={String(pageState?.pageSize || 10)}
+              onValueChange={handlePageSize}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">10 rows</SelectItem>
+                <SelectItem value="20">20 rows</SelectItem>
+                <SelectItem value="40">40 rows</SelectItem>
+                <SelectItem value="50">50 rows</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex gap-3">
+            <Button onClick={handlePrev} disabled={!pageState || pageState.page <= 1}>Prev</Button>
+            <Button variant="outline" disabled>{pageState?.page || 1}</Button>
+            <Button onClick={handleNext} disabled={!pageState || !totalPages || pageState.page >= totalPages}>Next</Button>
+          </div>
+
+
+        </div>
       </div>
     </MotionConfig>
   );

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -57,8 +57,10 @@ interface DataTableProps<TData, TValue> {
   totalPages: number;
   filters: TransactionFilters;
   setFilters: (value: TransactionFilters) => void;
-  sorting: { key: string; order: "asc" | "desc" } | null;
-  setSorting: (value: { key: string; order: "asc" | "desc" } | null) => void
+  sorting: { key: string, order: "asc" | "desc" } | null;
+  setSorting: (value: { key: string, order: "asc" | "desc" } | null) => void
+  availableSymbols: { stockSymbol: string }[]
+
 }
 
 
@@ -72,7 +74,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   "use no memo";
 
 
-  const { sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
+  const { availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
 
 
   /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table's useReactTable() returns functions that cannot be memoized safely */
@@ -112,10 +114,13 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       <div className="flex h-full min-h-0 flex-col rounded-lg border border-slate-700">
         <div className="shrink-0 rounded-t-lg border-b border-slate-700 bg-slate-800 px-2 py-2">
           <div className="flex flex-wrap items-center justify-start md:justify-end gap-2 w-full md:w-auto">
-            <DataTableFilters data={data as Transaction[]} onFilterChange={(newFilters: any) => {
-              setFilters(newFilters);
-              setPageState((prev: any) => ({ ...prev, page: 1 }));
-            }} activeFilters={filters} />
+            <DataTableFilters
+              data={data as Transaction[]}
+              availableSymbols={availableSymbols?.map((val: { stockSymbol: string }) => val.stockSymbol)}
+              onFilterChange={(newFilters: any) => {
+                setFilters(newFilters);
+                setPageState((prev: any) => ({ ...prev, page: 1 }));
+              }} activeFilters={filters} />
             {shouldShowMobileLayout !== undefined && onToggleView ? (
               <TableViewToggle
                 shouldShowMobileLayout={shouldShowMobileLayout}

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -37,6 +37,14 @@ interface TransactionFilters {
   symbols?: string[];
 }
 
+
+interface pageState {
+  page: number,
+  pageSize: number
+
+}
+
+
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
@@ -44,13 +52,13 @@ interface DataTableProps<TData, TValue> {
   shouldShowMobileLayout?: boolean;
   onToggleView?: (fullTable: boolean) => void;
   renderMobileSubRow?: (original: TData) => React.ReactNode;
-  pageState: any;
-  setPageState?: any;
-  totalPages?: number;
-  filters?: TransactionFilters;
-  setFilters?: any;
-  sorting?: { key: string; order: string } | null;
-  setSorting?: any;
+  pageState: pageState;
+  setPageState: (value: pageState) => void;
+  totalPages: number;
+  filters: TransactionFilters;
+  setFilters: (value: TransactionFilters) => void;
+  sorting: { key: string; order: "asc" | "desc" } | null;
+  setSorting: (value: { key: string; order: "asc" | "desc" } | null) => void
 }
 
 

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTableFilters.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTableFilters.tsx
@@ -20,9 +20,10 @@ interface DataTableFiltersProps {
     types?: string[];
     symbols?: string[];
   };
+  availableSymbols: string[]
 }
 
-export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTableFiltersProps) {
+export function DataTableFilters({ data, onFilterChange, activeFilters, availableSymbols }: DataTableFiltersProps) {
   // State for dropdown open/close
   const [isOpen, setIsOpen] = useState(false);
 
@@ -47,7 +48,7 @@ export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTa
   })();
 
   // Extract unique stock symbols from data
-  const stockSymbols = (() => {
+  const stockSymbol = (() => {
     const symbols = new Set<string>();
     data.forEach((transaction) => {
       symbols.add(transaction.stockSymbol);
@@ -55,6 +56,7 @@ export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTa
     return Array.from(symbols).sort();
   })();
 
+  const stockSymbols = availableSymbols ?? stockSymbol
   const toggleTypeFilter = (type: string) => {
     const currentTypes = pendingFilters.types || [];
     const newTypes = currentTypes.includes(type) ? currentTypes.filter((t) => t !== type) : [...currentTypes, type];
@@ -131,7 +133,7 @@ export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTa
 
           <DropdownMenuLabel>Stock Symbol</DropdownMenuLabel>
           <div className="max-h-[200px] overflow-y-auto">
-            {stockSymbols.map((symbol) => (
+            {stockSymbols?.map((symbol) => (
               <DropdownMenuCheckboxItem
                 key={`symbol-${symbol}`}
                 checked={pendingFilters.symbols?.includes(symbol)}

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/columns.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/columns.tsx
@@ -136,6 +136,7 @@ export const getTransactionsTableDesktopColumns = (
 
       return <div className={getProfitLossColorClass(changePct)}>{formatSignedPercentage(changePct)}</div>;
     },
+     enableSorting: false,
   },
   {
     accessorKey: "totalValue",
@@ -145,6 +146,7 @@ export const getTransactionsTableDesktopColumns = (
       const totalValue = calculateTotalValue(row.original);
       return <div>{formatCurrency(totalValue)}</div>;
     },
+    enableSorting: false, 
   },
   {
     accessorKey: "commissionAndTaxes",
@@ -154,6 +156,7 @@ export const getTransactionsTableDesktopColumns = (
       const value = calculateCommissionAndTaxes(row.original);
       return value ? <div>{formatCurrency(value)}</div> : <div>-</div>;
     },
+    enableSorting: false, 
   },
   {
     id: "actions",

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -21,7 +21,7 @@ interface TransactionsTableProps {
 }
 
 interface TransactionFilters {
-  types?: ("buy" | "sell" | "dividend")[];
+  types?: string[];
   symbols?: string[];
 }
 

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -6,7 +6,7 @@ import useBreakpoint from "@/utils/hooks/useBreakpoints";
 import { useTransactions } from "@/utils/hooks/useTransactionData";
 import { useQuery } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
-import React from "react";
+import React, { useState } from "react";
 import { DataTable } from "./components/DataTable";
 import {
   getChangeSinceTransactionPct,
@@ -20,6 +20,11 @@ interface TransactionsTableProps {
   portfolioId: number;
 }
 
+interface TransactionFilters {
+  types?: ("buy" | "sell" | "dividend")[];
+  symbols?: string[];
+}
+
 export const TransactionsTable = (props: TransactionsTableProps) => {
   const { portfolioId } = props;
 
@@ -28,7 +33,17 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
 
   const [shouldShowFullTable, setShouldShowFullTable] = React.useState(!shouldShowMobileLayout);
 
-  const { transactions } = useTransactions(portfolioId);
+  const [pageState, setPageState] = useState({
+    page: 1,
+    pageSize: 10,
+  });
+
+  const [filters, setFilters] = React.useState<TransactionFilters>({});
+  const [sorting, setSorting] = React.useState<{ key: string; order: string } | null>(null);
+
+  const { transactions } = useTransactions(portfolioId, pageState.page, pageState.pageSize, filters, sorting);
+  const totalPages = transactions?.data?.totalPages;
+
   const pricesQuery = useQuery({
     ...stockPriceQueries.latestAll(),
     select: (data) => {
@@ -45,7 +60,7 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
   };
 
   const pricesBySymbol = pricesQuery.data ?? {};
-  const allTransactions = (transactions.data as Transaction[]) || [];
+  const allTransactions = transactions.data?.items || [];
   const columns = shouldShowFullTable
     ? getTransactionsTableDesktopColumns(pricesBySymbol)
     : getTransactionsTableMobileColumns();
@@ -82,6 +97,13 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
         shouldShowMobileLayout={!shouldShowFullTable}
         onToggleView={handleToggle}
         renderMobileSubRow={!shouldShowFullTable ? renderMobileSubRow : undefined}
+        pageState={pageState}
+        setPageState={setPageState}
+        totalPages={totalPages}
+        filters={filters}
+        setFilters={setFilters}
+        sorting={sorting}
+        setSorting={setSorting}
       />
     </>
   );

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -39,11 +39,10 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
   });
 
   const [filters, setFilters] = React.useState<TransactionFilters>({});
-  const [sorting, setSorting] = React.useState<{ key: string; order: string } | null>(null);
+  const [sorting, setSorting] = React.useState<{ key: string, order: "asc" | "desc" } | null>(null);
 
   const { transactions } = useTransactions(portfolioId, pageState.page, pageState.pageSize, filters, sorting);
-  const totalPages = transactions?.data?.totalPages;
-
+  const totalPages = transactions?.data?.totalPages ?? 0;
   const pricesQuery = useQuery({
     ...stockPriceQueries.latestAll(),
     select: (data) => {
@@ -104,6 +103,8 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
         setFilters={setFilters}
         sorting={sorting}
         setSorting={setSorting}
+        availableSymbols={transactions.data?.availableSymbols ?? []}
+
       />
     </>
   );

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -77,6 +77,7 @@ const MotionButton = motion.create(Button);
 const TableHeaderCell = ({ column, heading }: { column: any; heading: string }) => {
   "use no memo";
   const sortDirection = column.getIsSorted();
+  const canSort = column.getCanSort();
 
   // Function to get the appropriate icon
   const getSortIcon = () => {
@@ -90,6 +91,14 @@ const TableHeaderCell = ({ column, heading }: { column: any; heading: string }) 
     }
   };
   const isAscending = sortDirection === "asc";
+
+  if (!canSort) {
+    return (
+      <div className="pl-2 -ml-[0.7rem] relative h-10 flex items-center">
+        <p className="text-gray-100 font-semibold text-left mr-2">{heading}</p>
+      </div>
+    );
+  }
 
   return (
     <MotionButton

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -33,6 +33,9 @@ export const useTransactions = (
           page: number;
           pageSize: number;
           totalPages: number;
+          availableSymbols:{stockSymbol:string}[]
+
+          
         };
       }
       throw new Error(result.message);

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -17,7 +17,7 @@ export const useTransactions = (
   portfolioId: number,
   page: number = 1,
   pageSize: number = 10,
-  filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+  filters?: { types?: string[]; symbols?: string[] },
   sorting?: { key: string; order: string } | null
 ) => {
   const queryClient = useQueryClient();

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -13,15 +13,27 @@ import { Transaction, TransactionSchemaType } from "@/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { handleServerPromise } from "../helpers";
 
-export const useTransactions = (portfolioId: number) => {
+export const useTransactions = (
+  portfolioId: number,
+  page: number = 1,
+  pageSize: number = 10,
+  filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+  sorting?: { key: string; order: string } | null
+) => {
   const queryClient = useQueryClient();
 
   const transactions = useQuery({
-    queryKey: ["transactions", portfolioId],
+    queryKey: ["transactions", portfolioId, page, pageSize, filters, sorting],
     queryFn: async () => {
-      const result = await getTransactions(portfolioId);
+      const result = await getTransactions(portfolioId, page, pageSize, filters, sorting );
       if (result.success) {
-        return result.data as unknown as Transaction[];
+        return result.data as unknown as {
+          items: Transaction[];
+          totalCount: number;
+          page: number;
+          pageSize: number;
+          totalPages: number;
+        };
       }
       throw new Error(result.message);
     },


### PR DESCRIPTION
# feat: implement server-side pagination, filtering, and sorting for transaction tabel

## What changed

Implemented  server-side pagination,filtering and sorting for transaction tabel,
In this pr sorting and filtering is move from client side to server side and for the columns that are calculated on frontend ,Like TotalValue and 2 Others ,Sorting on these remove at All As this should be done in a seperate pr , for now sorting apply on the columns that exists in db . 

filtering and sorting is remove from thenstack table and move entirely on backend.

## Why

Server side Pagination is added because it helps reduce loads on the user brower, 
So that user brower should not lag under large data

## Linked Issue

 issue : https://github.com/Wajahat43/psxworth/issues/11

## Testing

<!-- How you verified the change -->

## Screenshots / video (UI changes only)

### before
https://github.com/user-attachments/assets/bb4187b1-ece8-4e18-94db-3f9f1d804563

### after


https://github.com/user-attachments/assets/e7472bf4-adac-4221-b0e7-dfc9afd047ac




## Checklist

- [x] PR targets `develop` (not `main`)
- [x] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint:types` pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated transactions with page-size selector, Prev/Next navigation, and total pages.
  * Server-backed filtering by transaction type and stock symbol; symbol dropdown shows available symbols.

* **UI**
  * Clickable column headers to toggle ascending/descending sort; some computed/value columns are non-sortable.
  * Changing filters, sorting, or page size resets to page 1 for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->