### PR TITLE
feat: auto-fill shares field for dividend transactions based on ex-dividend date

### DIFF
--- a/src/actions/payouts/index.ts
+++ b/src/actions/payouts/index.ts
@@ -3,7 +3,7 @@
 import { withErrorHandling, requireAuth } from "@/actions/utils/middleware";
 import { dataDb } from "@/db";
 import { payouts } from "@/db/datadb-schema";
-import { and, gte, inArray, lte } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte } from "drizzle-orm";
 
 type GetUpcomingPayoutsParams = {
   symbols: string[];
@@ -92,3 +92,36 @@ export const getAllUpcomingPayouts = withErrorHandling(async ({ from, to, limit 
 
   return rows as UpcomingPayoutRecord[];
 });
+
+/**
+ * Fetches the most recent dividend payout for a given stock symbol.
+ * Used to determine the ex-dividend date for auto-filling shares in the transaction form.
+ * Only looks at past payouts (exDate <= today) to find the latest completed dividend cycle.
+ */
+
+export const getMostRecentDividendPayoutForSymbol = withErrorHandling(
+  async (symbol: string) => {
+    await requireAuth();
+
+    if (!symbol) return null;
+
+    const rows = await dataDb
+      .select({
+        symbol: payouts.symbol,
+        exDate: payouts.exDate,
+        actionType: payouts.actionType,
+      })
+      .from(payouts)
+      .where(
+        and(
+          eq(payouts.symbol, symbol),
+          eq(payouts.actionType, "dividend"),
+          lte(payouts.exDate, new Date())
+        )
+      )
+      .orderBy(desc(payouts.exDate))
+      .limit(1);
+
+    return rows[0] ?? null;
+  }
+);

--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
@@ -110,16 +110,16 @@ useEffect(() => {
 }, [stockSymbol, isDividend]);
 
 useEffect(() => {
-  if (editTransaction) return;
+  if (editTransaction || !isDividend) return;
 
   if (!hasUserEdited.current) {
     if (autoFilledShares !== null) {
-      form.setValue("numberOfShares", autoFilledShares);
+      form.setValue("numberOfShares", autoFilledShares, { shouldDirty: false });
     } else {
-      form.setValue("numberOfShares", 0);
+      form.setValue("numberOfShares", 0, { shouldDirty: false });
     }
   }
-}, [autoFilledShares, editTransaction, form]);
+}, [autoFilledShares, editTransaction, isDividend, form]);
 
   return (
     <Form {...form}>

--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
@@ -27,6 +27,8 @@ import {
 } from "../components/TransactionFormFields";
 import { TransactionSubmitButton } from "../components/TransactionSubmitButton";
 import { TransactionSummary } from "../components/TransactionSummary";
+import { useDividendSharesAutoFill } from "@/utils/hooks/useDividendSharesAutoFill";
+import { useEffect } from "react";
 
 interface TransactionFormProps {
   onSuccess?: () => void;
@@ -40,7 +42,7 @@ export default function TransactionForm(props: TransactionFormProps) {
 
   const { onSuccess, portfolioId, editTransaction, editTransactionId } = props;
 
-  const { createTransaction, updateTransaction } = useTransactions(portfolioId);
+  const { createTransaction, updateTransaction, transactions } = useTransactions(portfolioId);
 
   // Get the appropriate schema and type based on transaction type
   const editTransactionType = editTransaction?.type || "buy";
@@ -91,6 +93,23 @@ export default function TransactionForm(props: TransactionFormProps) {
       });
     }
   };
+  
+
+  const stockSymbol = form.watch("stockSymbol");
+
+  const autoFilledShares = useDividendSharesAutoFill(
+    stockSymbol,
+    isDividend,
+    transactions.data ?? []
+  );
+
+  useEffect(() => {
+    // Only auto-fill for new transactions, not edits
+    if (autoFilledShares !== null && !editTransaction) {
+      form.setValue("numberOfShares", autoFilledShares);
+    }
+  }, [autoFilledShares, editTransaction, form]);
+
 
   return (
     <Form {...form}>

--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
@@ -28,7 +28,7 @@ import {
 import { TransactionSubmitButton } from "../components/TransactionSubmitButton";
 import { TransactionSummary } from "../components/TransactionSummary";
 import { useDividendSharesAutoFill } from "@/utils/hooks/useDividendSharesAutoFill";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface TransactionFormProps {
   onSuccess?: () => void;
@@ -97,19 +97,29 @@ export default function TransactionForm(props: TransactionFormProps) {
 
   const stockSymbol = form.watch("stockSymbol");
 
-  const autoFilledShares = useDividendSharesAutoFill(
-    stockSymbol,
-    isDividend,
-    transactions.data ?? []
-  );
+const autoFilledShares = useDividendSharesAutoFill(
+  stockSymbol,
+  isDividend,
+  transactions.data ?? []
+);
 
-  useEffect(() => {
-    // Only auto-fill for new transactions, not edits
-    if (autoFilledShares !== null && !editTransaction) {
+const hasUserEdited = useRef(false);
+
+useEffect(() => {
+  hasUserEdited.current = false;
+}, [stockSymbol, isDividend]);
+
+useEffect(() => {
+  if (editTransaction) return;
+
+  if (!hasUserEdited.current) {
+    if (autoFilledShares !== null) {
       form.setValue("numberOfShares", autoFilledShares);
+    } else {
+      form.setValue("numberOfShares", 0);
     }
-  }, [autoFilledShares, editTransaction, form]);
-
+  }
+}, [autoFilledShares, editTransaction, form]);
 
   return (
     <Form {...form}>
@@ -129,7 +139,17 @@ export default function TransactionForm(props: TransactionFormProps) {
         <FormField
           control={form.control}
           name="numberOfShares"
-          render={({ field }) => <SharesCountInput field={field} />}
+          render={({ field }) => (
+            <SharesCountInput
+              field={{
+                ...field,
+                onChange: (e) => {
+                  hasUserEdited.current = true;
+                  field.onChange(e);
+                },
+              }}
+            />
+          )}
         />
 
         {/* Conditionally render pricePerShare for buy/sell or dividendPerShare for dividend */}

--- a/src/utils/hooks/useDividendSharesAutoFill.ts
+++ b/src/utils/hooks/useDividendSharesAutoFill.ts
@@ -24,30 +24,36 @@ export function useDividendSharesAutoFill(
   const [autoFilledShares, setAutoFilledShares] = useState<number | null>(null);
 
   useEffect(() => {
-  async function calculate() {
-    // Handle the null case INSIDE the async function
-    if (!isDividend || !symbol) {
-      setAutoFilledShares(null);
-      return;
+    let cancelled = false;
+
+    async function calculate() {
+      if (!isDividend || !symbol) {
+        setAutoFilledShares(null);
+        return;
+      }
+
+      const result = await getMostRecentDividendPayoutForSymbol(symbol);
+      if (cancelled) return; // discard stale response
+
+      const payoutData = result && 'success' in result && result.success
+        ? (result.data as { symbol: string; exDate: string | Date; actionType: string } | null)
+        : null;
+      const exDate = payoutData?.exDate ? new Date(payoutData.exDate) : null;
+
+      if (exDate) {
+        const eligible = calculateHoldingsAsOf(transactions, symbol, exDate);
+        if (!cancelled) setAutoFilledShares(eligible >= 0 ? eligible : null);
+      } else {
+        const current = calculateHoldingsAsOf(transactions, symbol, new Date());
+        if (!cancelled) setAutoFilledShares(current > 0 ? current : null);
+      }
     }
 
-    const result = await getMostRecentDividendPayoutForSymbol(symbol);
-    const payoutData = result && 'success' in result && result.success
-      ? (result.data as { symbol: string; exDate: string | Date; actionType: string } | null)
-      : null;
-    const exDate = payoutData?.exDate ? new Date(payoutData.exDate) : null;
+    calculate();
 
-    if (exDate) {
-      const eligible = calculateHoldingsAsOf(transactions, symbol, exDate);
-      setAutoFilledShares(eligible >= 0 ? eligible : null);
-    } else {
-      const current = calculateHoldingsAsOf(transactions, symbol, new Date());
-      setAutoFilledShares(current > 0 ? current : null);
-    }
-  }
+    return () => { cancelled = true; }; 
 
-  calculate();
-}, [symbol, isDividend, transactions]);
+  }, [symbol, isDividend, transactions]);
 
   return autoFilledShares;
 }

--- a/src/utils/hooks/useDividendSharesAutoFill.ts
+++ b/src/utils/hooks/useDividendSharesAutoFill.ts
@@ -1,0 +1,53 @@
+import { getMostRecentDividendPayoutForSymbol } from "@/actions/payouts";
+import { Transaction } from "@/types";
+import { useEffect, useState } from "react";
+
+function calculateHoldingsAsOf(
+  transactions: Transaction[],
+  symbol: string,
+  asOfDate: Date
+): number {
+  return transactions
+    .filter((t) => t.stockSymbol === symbol && new Date(t.transactionDate) < asOfDate)
+    .reduce((total, t) => {
+      if (t.type === "buy") return total + (t.numberOfShares ?? 0);
+      if (t.type === "sell") return total - (t.numberOfShares ?? 0);
+      return total;
+    }, 0);
+}
+
+export function useDividendSharesAutoFill(
+  symbol: string | undefined,
+  isDividend: boolean,
+  transactions: Transaction[]
+): number | null {
+  const [autoFilledShares, setAutoFilledShares] = useState<number | null>(null);
+
+  useEffect(() => {
+  async function calculate() {
+    // Handle the null case INSIDE the async function
+    if (!isDividend || !symbol) {
+      setAutoFilledShares(null);
+      return;
+    }
+
+    const result = await getMostRecentDividendPayoutForSymbol(symbol);
+    const payoutData = result && 'success' in result && result.success
+      ? (result.data as { symbol: string; exDate: string | Date; actionType: string } | null)
+      : null;
+    const exDate = payoutData?.exDate ? new Date(payoutData.exDate) : null;
+
+    if (exDate) {
+      const eligible = calculateHoldingsAsOf(transactions, symbol, exDate);
+      setAutoFilledShares(eligible >= 0 ? eligible : null);
+    } else {
+      const current = calculateHoldingsAsOf(transactions, symbol, new Date());
+      setAutoFilledShares(current > 0 ? current : null);
+    }
+  }
+
+  calculate();
+}, [symbol, isDividend, transactions]);
+
+  return autoFilledShares;
+}


### PR DESCRIPTION
## What changed
Added auto fill for the number of shares field when adding the dividend transaction, and when the user selects the stock 
and switches to dividend type, and the shares automatically populate with the number of shares held before the ex-dividend date of the most recent payout for that symbol.

## Why
Users had to manually type the share count for dividend transactions, even though
The data already exists in the portfolio's transaction history and the payouts table.

## Linked Issue
Closes #26

## Testing
1. Add a Buy transaction for any stock (e.g., UBL) with a date before 2026-03-19
2. Open Add Transaction → select Dividend → select UBL
3. Shares field auto-fills with the eligible count from step 1
4. Manually override the value — it stays overridden
5. Open an existing dividend transaction to edit — shows original value, not auto-filled

## Checklist
- [x] PR targets `develop` (not `main`)
- [x] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint: types` pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dividend transaction forms now auto-fill the number of shares eligible at the dividend record date using the most recent dividend information, improving accuracy when entering dividend transactions.
  * The shares input now preserves manual edits and won't be overwritten by auto-fill once you adjust the value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->