### PR TITLE
fix: unify color styling and clean up error pages

### DIFF
--- a/src/app/blocked/page.tsx
+++ b/src/app/blocked/page.tsx
@@ -1,4 +1,7 @@
+import { ErrorState } from "@/components/molecules/ErrorState";
+import { Button } from "@/components/ui/button";
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   robots: {
@@ -9,10 +12,16 @@ export const metadata: Metadata = {
 
 export default function Blocked() {
   return (
-    <div className="flex flex-col items-center justify-center h-screen">
-      <h1 className="text-4xl font-bold">Access blocked. </h1>
-      <h3 className="text-2xl font-bold">You have been rate limited. Please try again after some time</h3>
-      <p className="text-lg">Please try again later.</p>
+    <div className="flex min-h-screen items-center justify-center px-4 py-10">
+      <ErrorState
+        title="Access temporarily blocked"
+        description="You have been rate limited. Please try again after some time."
+        action={
+          <Button asChild>
+            <Link href="/portfolio">Back to portfolio</Link>
+          </Button>
+        }
+      />
     </div>
   );
 }

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,26 +1,31 @@
 "use client";
 
 // Error boundaries must be Client Components
-import NextError from "next/error";
+import { ErrorState } from "@/components/molecules/ErrorState";
+import { Button } from "@/components/ui/button";
 import posthog from "posthog-js";
 import { useEffect } from "react";
 
-export default function GlobalError({
-  error,
-}: {
-  error: Error & { digest?: string };
-  reset: () => void;
-}) {
+export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     posthog.captureException(error);
   }, [error]);
 
   return (
     // global-error must include html and body tags
-    <html>
+    <html lang="en">
       <body>
-        {/* `NextError` is the default Next.js error page component */}
-        <NextError statusCode={0} />
+        <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-foreground">
+          <ErrorState
+            title="Application error"
+            description="Something prevented the app from loading correctly."
+            action={
+              <Button onClick={reset} variant="destructive">
+                Reload app
+              </Button>
+            }
+          />
+        </main>
       </body>
     </html>
   );

--- a/src/app/portfolio/[portfolioId]/components/Allocation/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/Allocation/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { STOCKS_INFO } from "@/utils/constants/stockSymbols";
+import { AlertTriangle } from "lucide-react";
 import { useState } from "react";
 import { AllocationChart } from "./components/AllocationChart";
 import { AllocationHeader } from "./components/AllocationHeader";
@@ -37,8 +38,12 @@ export const AllocationPage = ({ stocks }: AllocationProps) => {
           </div>
         )}
         {error && (
-          <div className="mb-4 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
-            Could not load ETF allocation details. Existing allocations are still shown; you can retry or collapse ETFs.
+          <div className="mb-4 flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p className="flex-1">
+              Could not load ETF allocation details. Existing allocations are still shown; you can retry or collapse
+              ETFs.
+            </p>
           </div>
         )}
         {data.length > 0 ? (

--- a/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/index.tsx
@@ -143,11 +143,11 @@ export const CreatePortfolioForm = ({ onSuccess, portfolio }: CreatePortfolioFor
               {...register("title")}
               placeholder="My Investment Portfolio"
               className={`h-11 rounded-md border-white/10 bg-blue-950/30 text-base text-gray-100 shadow-sm backdrop-blur-sm placeholder:text-gray-400 focus:border-blue-400 focus:ring-1 focus:ring-blue-400 ${
-                errors.title ? "border-red-500 focus:border-red-500 focus:ring-red-500" : ""
+                errors.title ? "border-destructive focus:border-destructive focus:ring-destructive/20" : ""
               }`}
             />
           </motion.div>
-          {errors.title?.message && <p className="mt-1 text-sm text-red-400">{errors.title.message as string}</p>}
+          {errors.title?.message && <p className="mt-1 text-sm text-destructive">{errors.title.message as string}</p>}
 
           {portfolio && <input type="hidden" {...register("id")} value={portfolio.id} />}
         </div>

--- a/src/app/portfolio/[portfolioId]/page.tsx
+++ b/src/app/portfolio/[portfolioId]/page.tsx
@@ -1,9 +1,11 @@
 import { getPortfolios } from "@/actions/portfolio/portfolioActions";
 import { getDetailedPortfolioPerformance } from "@/actions/portfolioPerformance/portfolioPerformance";
-import { Portfolio } from "@/db/schema";
+import { ErrorState } from "@/components/molecules/ErrorState";
 import CommunityPromptHandler from "@/components/organisms/CommunityJoinPrompt/CommunityPromptHandler";
 import { Button } from "@/components/ui/button";
+import { Portfolio } from "@/db/schema";
 import { Metadata } from "next";
+import Link from "next/link";
 import { PortfolioCookieSetter } from "./components/PortfolioCookieSetter";
 import { PortfolioPageTabs } from "./components/PortfolioPageTabs";
 
@@ -29,15 +31,20 @@ type PortfolioPageProps = {
 export default async function PortfolioPage({ params }: PortfolioPageProps) {
   const { portfolioId: portfolioIdString } = await params;
   const portfolioId = Number(portfolioIdString);
+  const retryAction = (
+    <Button asChild>
+      <Link href="/portfolio">Back to portfolio</Link>
+    </Button>
+  );
 
   if (Number.isNaN(portfolioId)) {
     return (
       <div className="flex h-full flex-col items-center justify-center p-4 text-center">
-        <h2 className="mb-4 text-2xl font-bold text-red-500">Invalid Portfolio</h2>
-        <p className="text-lg text-gray-200">The provided portfolio ID is invalid.</p>
-        <Button asChild>
-          <a href="/portfolio">Click here to try again</a>
-        </Button>
+        <ErrorState
+          title="Invalid portfolio"
+          description="The provided portfolio ID is invalid."
+          action={retryAction}
+        />
         <PortfolioCookieSetter shouldDelete={true} />
       </div>
     );
@@ -57,11 +64,7 @@ export default async function PortfolioPage({ params }: PortfolioPageProps) {
 
     return (
       <div className="flex h-full flex-col items-center justify-center p-4 text-center">
-        <h2 className="mb-4 text-2xl font-bold text-red-500">Something Went Wrong</h2>
-        <p className="text-lg text-gray-200">{errorMessage}</p>
-        <Button asChild>
-          <a href="/portfolio">Click here to try again</a>
-        </Button>
+        <ErrorState title="Something went wrong" description={errorMessage} action={retryAction} />
         <PortfolioCookieSetter shouldDelete={true} />
       </div>
     );
@@ -75,11 +78,7 @@ export default async function PortfolioPage({ params }: PortfolioPageProps) {
 
     return (
       <div className="flex h-full flex-col items-center justify-center p-4 text-center">
-        <h2 className="mb-4 text-2xl font-bold text-red-500">Something Went Wrong</h2>
-        <p className="text-lg text-gray-200">{errorMessage}</p>
-        <Button asChild>
-          <a href="/portfolio">Click here to try again</a>
-        </Button>
+        <ErrorState title="Something went wrong" description={errorMessage} action={retryAction} />
         <PortfolioCookieSetter shouldDelete={true} />
       </div>
     );
@@ -89,11 +88,7 @@ export default async function PortfolioPage({ params }: PortfolioPageProps) {
   if (!portfoliosList) {
     return (
       <div className="flex h-full flex-col items-center justify-center p-4 text-center">
-        <h2 className="mb-4 text-2xl font-bold text-red-500">Something Went Wrong</h2>
-        <p className="text-lg text-gray-200">Unable to load portfolios</p>
-        <Button asChild>
-          <a href="/portfolio">Click here to try again</a>
-        </Button>
+        <ErrorState title="Something went wrong" description="Unable to load portfolios" action={retryAction} />
         <PortfolioCookieSetter shouldDelete={true} />
       </div>
     );
@@ -102,14 +97,9 @@ export default async function PortfolioPage({ params }: PortfolioPageProps) {
 
   if (!portfolioInfo) {
     return (
-      <div>
+      <div className="flex h-full flex-col items-center justify-center p-4 text-center">
         <PortfolioCookieSetter shouldDelete={true} />
-        <h2 className="mb-4 text-2xl font-bold text-red-500">Something Went Wrong</h2>
-        <p className="text-lg text-gray-200">Unable to load portfolio</p>
-
-        <Button asChild>
-          <a href="/portfolio">Click here to try again</a>
-        </Button>
+        <ErrorState title="Something went wrong" description="Unable to load portfolio" action={retryAction} />
       </div>
     );
   }

--- a/src/app/portfolio/error.tsx
+++ b/src/app/portfolio/error.tsx
@@ -1,25 +1,26 @@
 "use client";
 
+import { ErrorState } from "@/components/molecules/ErrorState";
+import { Button } from "@/components/ui/button";
 import posthog from "posthog-js";
 import { useEffect } from "react";
 
-export default function Error({
-  error,
-}: {
-  error: Error & { digest?: string };
-}) {
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   useEffect(() => {
     posthog.captureException(error);
   }, [error]);
 
   return (
-    <div className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center">
-      <h2 className="text-2xl font-semibold text-red-400">
-        Something went wrong!
-      </h2>
-      <p className="text-gray-600">Please try again later.</p>
-      {/* Display the error message for debugging */}
-      <p className="text-sm text-gray-400 mt-2">{error.message}</p>
+    <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-10">
+      <ErrorState
+        title="Portfolio error"
+        description={error.message || "Please try again later."}
+        action={
+          <Button onClick={reset} variant="destructive">
+            Try again
+          </Button>
+        }
+      />
     </div>
   );
 }

--- a/src/app/portfolio/error.tsx
+++ b/src/app/portfolio/error.tsx
@@ -14,7 +14,7 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
     <div className="flex min-h-[calc(100vh-8rem)] items-center justify-center px-4 py-10">
       <ErrorState
         title="Portfolio error"
-        description={error.message || "Please try again later."}
+        description="We couldn't load this portfolio. Please try again later."
         action={
           <Button onClick={reset} variant="destructive">
             Try again

--- a/src/components/icons/WhatsAppIcon.tsx
+++ b/src/components/icons/WhatsAppIcon.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { IconProps } from "./types";
 
-const GitHubIcon: FC<IconProps> = ({
+const WhatsAppIcon: FC<IconProps> = ({
   size = 24,
   color = "currentColor",
   ...props
@@ -27,4 +27,4 @@ const GitHubIcon: FC<IconProps> = ({
   );
 };
 
-export default GitHubIcon;
+export default WhatsAppIcon;

--- a/src/components/molecules/ErrorState/index.tsx
+++ b/src/components/molecules/ErrorState/index.tsx
@@ -10,10 +10,12 @@ type ErrorStateProps = {
 export function ErrorState({ title, description, action, className = "" }: ErrorStateProps) {
   return (
     <div
+      role="alert"
+      aria-live="assertive"
       className={`flex min-h-[320px] flex-col items-center justify-center rounded-2xl border border-destructive/20 bg-card px-6 py-10 text-center shadow-sm ${className}`}
     >
       <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-destructive/30 bg-destructive/10 text-destructive">
-        <AlertTriangle className="h-6 w-6" />
+        <AlertTriangle aria-hidden="true" className="h-6 w-6" />
       </div>
       <h2 className="text-2xl font-semibold tracking-tight text-destructive">{title}</h2>
       <p className="mt-3 max-w-xl text-sm text-muted-foreground sm:text-base">{description}</p>

--- a/src/components/molecules/ErrorState/index.tsx
+++ b/src/components/molecules/ErrorState/index.tsx
@@ -1,0 +1,25 @@
+import { AlertTriangle } from "lucide-react";
+
+type ErrorStateProps = {
+  title: string;
+  description: React.ReactNode;
+  action?: React.ReactNode;
+  className?: string;
+};
+
+export function ErrorState({ title, description, action, className = "" }: ErrorStateProps) {
+  return (
+    <div
+      className={`flex min-h-[320px] flex-col items-center justify-center rounded-2xl border border-destructive/20 bg-card px-6 py-10 text-center shadow-sm ${className}`}
+    >
+      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-destructive/30 bg-destructive/10 text-destructive">
+        <AlertTriangle className="h-6 w-6" />
+      </div>
+      <h2 className="text-2xl font-semibold tracking-tight text-destructive">{title}</h2>
+      <p className="mt-3 max-w-xl text-sm text-muted-foreground sm:text-base">{description}</p>
+      {action ? <div className="mt-6">{action}</div> : null}
+    </div>
+  );
+}
+
+export default ErrorState;

--- a/src/components/molecules/ErrorState/index.tsx
+++ b/src/components/molecules/ErrorState/index.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { AlertTriangle } from "lucide-react";
 
 type ErrorStateProps = {
@@ -12,7 +13,10 @@ export function ErrorState({ title, description, action, className = "" }: Error
     <div
       role="alert"
       aria-live="assertive"
-      className={`flex min-h-[320px] flex-col items-center justify-center rounded-2xl border border-destructive/20 bg-card px-6 py-10 text-center shadow-sm ${className}`}
+      className={cn(
+        "flex min-h-[320px] flex-col items-center justify-center rounded-2xl border border-destructive/20 bg-card px-6 py-10 text-center shadow-sm",
+        className
+      )}
     >
       <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full border border-destructive/30 bg-destructive/10 text-destructive">
         <AlertTriangle aria-hidden="true" className="h-6 w-6" />

--- a/src/components/molecules/payouts/upcoming/UpcomingPayoutsError.tsx
+++ b/src/components/molecules/payouts/upcoming/UpcomingPayoutsError.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AlertTriangle } from "lucide-react";
 import { motion } from "motion/react";
 import React from "react";
 
@@ -11,15 +12,16 @@ export const UpcomingPayoutsError: React.FC<Props> = ({ message = "Failed to loa
       layout
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      className="rounded-lg border border-border bg-card p-3"
+      className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-destructive"
     >
-      <div className="flex items-center justify-between gap-3">
-        <div className="text-muted-foreground">{message}</div>
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="min-w-0 flex-1 text-sm font-medium">{message}</div>
         {onRetry ? (
           <button
             type="button"
             onClick={onRetry}
-            className="px-2.5 py-1.5 rounded-md border border-border bg-secondary text-foreground hover:opacity-90 transition"
+            className="rounded-md border border-destructive/30 bg-background/30 px-2.5 py-1.5 text-sm font-medium text-destructive transition hover:bg-destructive/15"
           >
             Retry
           </button>

--- a/src/features/historicalReturns/components/HistoricalReturnsChart.tsx
+++ b/src/features/historicalReturns/components/HistoricalReturnsChart.tsx
@@ -156,7 +156,7 @@ export function HistoricalReturnsChart({ portfolioId }: HistoricalReturnsChartPr
         ) : error ? (
           <ErrorState
             title="Failed to load historical returns"
-            description={error instanceof Error ? error.message : "Failed to load data"}
+            description="Failed to load historical returns data. Please try again later."
             className="h-[400px] rounded-none border-0 bg-slate-900 shadow-none"
           />
         ) : !hasData ? (

--- a/src/features/historicalReturns/components/HistoricalReturnsChart.tsx
+++ b/src/features/historicalReturns/components/HistoricalReturnsChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ErrorState } from "@/components/molecules/ErrorState";
 import type { ApexOptions } from "apexcharts";
 import { Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
@@ -153,9 +154,11 @@ export function HistoricalReturnsChart({ portfolioId }: HistoricalReturnsChartPr
             </div>
           </div>
         ) : error ? (
-          <div className="flex h-[400px] items-center justify-center bg-slate-900 text-red-400">
-            {error instanceof Error ? error.message : "Failed to load data"}
-          </div>
+          <ErrorState
+            title="Failed to load historical returns"
+            description={error instanceof Error ? error.message : "Failed to load data"}
+            className="h-[400px] rounded-none border-0 bg-slate-900 shadow-none"
+          />
         ) : !hasData ? (
           <div className="flex h-[400px] items-center justify-center bg-slate-900 text-gray-400">
             No data available for the selected period


### PR DESCRIPTION
## What changed

Added a shared `ErrorState` component and updated app error surfaces to use consistent destructive styling. Replaced the repeated inline error blocks on the portfolio page, updated the portfolio error boundary, blocked page, payouts error card, historical returns error state, allocation error banner, create-portfolio form validation styling, and global error page.

## Why

The issue requested a consistent, reusable error UI across the app. This change removes duplicated error markup and unifies error styling under the design system’s `destructive` token instead of scattered raw Tailwind red classes.

Closes #3

## Testing

- `pnpm lint`
- `pnpm lint:types`
- `pnpm build` compiles successfully, but fails at the end on a Windows symlink permission issue when generating standalone output. This appears environmental, not related to the error-state changes.

## Screenshots / video (UI changes only)

Not attached.

## Checklist

- [x] PR targets `develop` (not `main`)
- [x] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint:types` pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global error page now includes a "Reload app" button to reset the application
  * Centralized error state component for consistent error messaging across the app

* **Bug Fixes & Improvements**
  * Error pages now display warning icons for better visual indication
  * Validation errors use consistent styling throughout the app
  * Rate-limited and error pages redesigned for improved user experience

* **Style**
  * Error states now use a unified destructive color scheme for better visual hierarchy
<!-- end of auto-generated comment: release notes by coderabbit.ai -->