### PR TITLE
Export All Transcations 

### DIFF
--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -112,7 +112,7 @@ const getTransactionsUncached = async (
   portfolioId: number,
   page: number = 1,
   pageSize: number = 20,
-  filters?: { types?: ("buy" | "sell" | "dividend")[], symbols?: string[] },
+  filters?: { types?: string[], symbols?: string[] },
   sorting?: { key: string; order: string } | null
 ) => {
   await withPortfolioOwnership(portfolioId, userId);
@@ -120,7 +120,7 @@ const getTransactionsUncached = async (
 
   const whereClause = and(
     eq(transactionTable.portfolioId, portfolioId),
-    filters?.types && filters.types.length > 0 ? inArray(transactionTable.type, filters.types) : undefined,
+    filters?.types && filters.types.length > 0 ? inArray(transactionTable.type, filters.types as ("buy" | "sell" | "dividend")[] ) : undefined,
     filters?.symbols && filters.symbols.length > 0 ? inArray(transactionTable.stockSymbol, filters.symbols) : undefined,
   );
 
@@ -173,7 +173,7 @@ export const getTransactions = withErrorHandling(
     portfolioId: number,
     page: number = 1,
     pageSize: number = 10,
-    filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+    filters?: { types?: string[]; symbols?: string[] },
     sorting?: { key: string; order: string } | null
   ) => {
     page = Math.max(1, page ?? 1);

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -138,8 +138,8 @@ const getTransactionsUncached = async (
   const orderByClause =
     sortColumn
       ? sorting?.order === "desc"
-        ? [desc(sortColumn)]
-        : [asc(sortColumn)]
+        ? [desc(sortColumn),asc(transactionTable.id)]
+        : [asc(sortColumn),asc(transactionTable.id)]
       : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
 
   const [transactions, totalCountResult,availableSymbols] = await Promise.all([
@@ -172,7 +172,7 @@ export const getTransactions = withErrorHandling(
   async (
     portfolioId: number,
     page: number = 1,
-    pageSize: number = 20,
+    pageSize: number = 10,
     filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
     sorting?: { key: string; order: string } | null
   ) => {

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -131,7 +131,7 @@ const getTransactionsUncached = async (
         : [asc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
       : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
 
-  const [transactions, totalCountResult] = await Promise.all([
+  const [transactions, totalCountResult,availableSymbols] = await Promise.all([
     db
       .select()
       .from(transactionTable)
@@ -143,11 +143,17 @@ const getTransactionsUncached = async (
       .select({ count: count() })
       .from(transactionTable)
       .where(whereClause),
+  db
+  .selectDistinct({ stockSymbol: transactionTable.stockSymbol })
+  .from(transactionTable)
+  .where(eq(transactionTable.portfolioId, portfolioId))
+
   ]);
 
   return {
     items: transactions,
     totalCount: Number(totalCountResult[0].count),
+    availableSymbols
   };
 };
 
@@ -184,7 +190,8 @@ export const getTransactions = withErrorHandling(
       totalCount: result.totalCount,
       page,
       pageSize,
-      totalPages: Math.ceil(result.totalCount / pageSize)
+      totalPages: Math.ceil(result.totalCount / pageSize),
+      availableSymbols:result.availableSymbols
     };
   }
 );

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -159,7 +159,10 @@ export const getTransactions = withErrorHandling(
     filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
     sorting?: { key: string; order: string } | null
   ) => {
-    
+    page = Math.max(1, page ?? 1);
+    pageSize = [10, 20, 40, 50].includes(pageSize)
+      ? pageSize
+      : 10;
 
     const userId = await requireAuth();
     await withPortfolioOwnership(portfolioId, userId);

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -124,11 +124,22 @@ const getTransactionsUncached = async (
     filters?.symbols && filters.symbols.length > 0 ? inArray(transactionTable.stockSymbol, filters.symbols) : undefined,
   );
 
+  const sortableColumns = {
+    transactionDate: transactionTable.transactionDate,
+    type: transactionTable.type,
+    stockSymbol: transactionTable.stockSymbol,
+    numberOfShares: transactionTable.numberOfShares,
+    pricePerShare: transactionTable.pricePerShare,
+    commissionAndTaxes: transactionTable.commissionAndTaxes,
+  } as const;
+
+  const sortColumn = sorting?.key ? sortableColumns[sorting.key as keyof typeof sortableColumns] : undefined;
+
   const orderByClause =
-    sorting?.key && sorting.key in transactionTable
-      ? sorting.order === "desc"
-        ? [desc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
-        : [asc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
+    sortColumn
+      ? sorting?.order === "desc"
+        ? [desc(sortColumn)]
+        : [asc(sortColumn)]
       : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
 
   const [transactions, totalCountResult,availableSymbols] = await Promise.all([

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -154,10 +154,10 @@ const getTransactionsUncached = async (
       .select({ count: count() })
       .from(transactionTable)
       .where(whereClause),
-  db
-  .selectDistinct({ stockSymbol: transactionTable.stockSymbol })
-  .from(transactionTable)
-  .where(eq(transactionTable.portfolioId, portfolioId))
+    db
+      .selectDistinct({ stockSymbol: transactionTable.stockSymbol })
+      .from(transactionTable)
+      .where(eq(transactionTable.portfolioId, portfolioId))
 
   ]);
 
@@ -211,14 +211,22 @@ export const getTransactions = withErrorHandling(
 export const getAllTransactions = withErrorHandling(
   async (
     portfolioId: number,
+    filters?: { types?: string[]; symbols?: string[] },
+
   ) => {
     const userId = await requireAuth();
     await withPortfolioOwnership(portfolioId, userId);
-const result = await db
-  .select()
-  .from(transactionTable)
-  .where(eq(transactionTable.portfolioId, portfolioId))
-  .orderBy(asc(transactionTable.transactionDate), asc(transactionTable.type));
+
+    const whereClause = and(
+      eq(transactionTable.portfolioId, portfolioId),
+      filters?.types && filters.types.length > 0 ? inArray(transactionTable.type, filters.types as ("buy" | "sell" | "dividend")[]) : undefined,
+      filters?.symbols && filters.symbols.length > 0 ? inArray(transactionTable.stockSymbol, filters.symbols) : undefined,
+    );
+    const result = await db
+      .select()
+      .from(transactionTable)
+      .where(whereClause)
+      .orderBy(asc(transactionTable.transactionDate), asc(transactionTable.type));
     return {
       items: result,
     };

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -207,6 +207,26 @@ export const getTransactions = withErrorHandling(
   }
 );
 
+
+export const getAllTransactions = withErrorHandling(
+  async (
+    portfolioId: number,
+  ) => {
+    const userId = await requireAuth();
+    await withPortfolioOwnership(portfolioId, userId);
+const result = await db
+  .select()
+  .from(transactionTable)
+  .where(eq(transactionTable.portfolioId, portfolioId))
+  .orderBy(asc(transactionTable.transactionDate), asc(transactionTable.type));
+    return {
+      items: result,
+    };
+  }
+);
+
+
+
 export const editTransaction = withErrorHandling(
   async (transactionId: number, updatedTransactionData: TransactionSchemaType) => {
     const userId = await requireAuth();

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -15,7 +15,7 @@ import { Transaction, TransactionSchemaType } from "@/types";
 import { MULTIPLE_TRANSACTIONS_CREATED, TRANSACTION_CREATED, TRANSACTION_DELETED } from "@/utils/posthog/events";
 import { generateObject } from "ai";
 import "dotenv/config";
-import { asc, eq } from "drizzle-orm";
+import { asc, desc, eq, and, inArray, count } from "drizzle-orm";
 import { unstable_cache, updateTag } from "next/cache";
 import { createResponse } from "../utils";
 import { requireAuth, withPortfolioOwnership, withErrorHandling } from "../utils/middleware";
@@ -107,34 +107,84 @@ export const parseRawTransactions = withErrorHandling(async (rawTransactions: st
   throw new Error("Transactions Couldn't be parsed properly. Please check if your data is valid.");
 });
 
-const getTransactionsUncached = async (userId: string, portfolioId: number) => {
+const getTransactionsUncached = async (
+  userId: string,
+  portfolioId: number,
+  page: number = 1,
+  pageSize: number = 20,
+  filters?: { types?: ("buy" | "sell" | "dividend")[], symbols?: string[] },
+  sorting?: { key: string; order: string } | null
+) => {
   await withPortfolioOwnership(portfolioId, userId);
-  const transactions = await db
-    .select()
-    .from(transactionTable)
-    .where(eq(transactionTable.portfolioId, portfolioId))
-    .orderBy(asc(transactionTable.transactionDate), asc(transactionTable.type));
+  const offset = Math.max(0, (page - 1) * pageSize);
 
-  return transactions;
+  const whereClause = and(
+    eq(transactionTable.portfolioId, portfolioId),
+    filters?.types && filters.types.length > 0 ? inArray(transactionTable.type, filters.types) : undefined,
+    filters?.symbols && filters.symbols.length > 0 ? inArray(transactionTable.stockSymbol, filters.symbols) : undefined,
+  );
+
+  const orderByClause =
+    sorting?.key && sorting.key in transactionTable
+      ? sorting.order === "desc"
+        ? [desc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
+        : [asc(transactionTable[sorting.key as keyof typeof transactionTable] as any)]
+      : [asc(transactionTable.transactionDate), asc(transactionTable.type)];
+
+  const [transactions, totalCountResult] = await Promise.all([
+    db
+      .select()
+      .from(transactionTable)
+      .where(whereClause)
+      .orderBy(...orderByClause)
+      .limit(pageSize)
+      .offset(offset),
+    db
+      .select({ count: count() })
+      .from(transactionTable)
+      .where(whereClause),
+  ]);
+
+  return {
+    items: transactions,
+    totalCount: Number(totalCountResult[0].count),
+  };
 };
 
-export const getTransactions = withErrorHandling(async (portfolioId: number) => {
-  const userId = await requireAuth();
-  await withPortfolioOwnership(portfolioId, userId);
+export const getTransactions = withErrorHandling(
+  async (
+    portfolioId: number,
+    page: number = 1,
+    pageSize: number = 20,
+    filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+    sorting?: { key: string; order: string } | null
+  ) => {
+    
 
-  const transactions = await unstable_cache(
-    async () => {
-      return await getTransactionsUncached(userId, portfolioId);
-    },
-    [`${userId}-${portfolioId}-transactions`],
-    {
-      tags: [`${userId}-${portfolioId}-transactions`],
-      revalidate: 60 * 60, //Revalidate after 1 hour.
-    }
-  )();
+    const userId = await requireAuth();
+    await withPortfolioOwnership(portfolioId, userId);
+    const filterKey = JSON.stringify(filters || {});
+    const sortKey = JSON.stringify(sorting || {});
+    const result = await unstable_cache(
+      async () => {
+        return await getTransactionsUncached(userId, portfolioId, page, pageSize, filters, sorting);
+      },
+      [`${userId}-${portfolioId}-transactions-page-${page}-size-${pageSize}-filters-${filterKey}-sorting-${sortKey}`],
+      {
+        tags: [`${userId}-${portfolioId}-transactions`],
+        revalidate: 60 * 60, //Revalidate after 1 hour.
+      }
+    )();
 
-  return transactions;
-});
+    return {
+      items: result.items,
+      totalCount: result.totalCount,
+      page,
+      pageSize,
+      totalPages: Math.ceil(result.totalCount / pageSize)
+    };
+  }
+);
 
 export const editTransaction = withErrorHandling(
   async (transactionId: number, updatedTransactionData: TransactionSchemaType) => {

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -1,20 +1,26 @@
 "use client";
 
+
+
+import {
+  Select,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select"
+
 import { ExportTransactionsButton } from "@/components/molecules/ExportTransactionsButton";
 import { TableToggleColumns } from "@/components/ui/TableToggleColumns";
 import { CustomTableRow, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { Transaction } from "@/types";
 import {
-  FilterFn,
   ColumnDef,
   flexRender,
-  SortingState,
   useReactTable,
   getCoreRowModel,
-  getSortedRowModel,
   getExpandedRowModel,
-  getFilteredRowModel,
 } from "@tanstack/react-table";
 import { Loader2 } from "lucide-react";
 import { motion, AnimatePresence, MotionConfig } from "motion/react";
@@ -22,8 +28,14 @@ import React from "react";
 import { TableViewToggle } from "../../TableViewToggle";
 import { TransactionDetailCard } from "../TransactionDetailCard";
 import { DataTableFilters } from "./DataTableFilters";
+import { Button } from "@/components/ui/button";
 
 const MotionTableRow = motion.create(TableRow);
+
+interface TransactionFilters {
+  types?: ("buy" | "sell" | "dividend")[];
+  symbols?: string[];
+}
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -31,14 +43,16 @@ interface DataTableProps<TData, TValue> {
   isLoading?: boolean;
   shouldShowMobileLayout?: boolean;
   onToggleView?: (fullTable: boolean) => void;
-  /** Renders a full-width row below each row when in mobile layout (e.g. "Since transaction") */
   renderMobileSubRow?: (original: TData) => React.ReactNode;
+  pageState: any;
+  setPageState?: any;
+  totalPages?: number;
+  filters?: TransactionFilters;
+  setFilters?: any;
+  sorting?: { key: string; order: string } | null;
+  setSorting?: any;
 }
 
-interface TransactionFilters {
-  types?: string[];
-  symbols?: string[];
-}
 
 const transition = {
   type: "spring",
@@ -48,49 +62,37 @@ const transition = {
 
 export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   "use no memo";
-  const { columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props;
-  const [sorting, setSorting] = React.useState<SortingState>([{ id: "transactionDate", desc: true }]);
-  const [filters, setFilters] = React.useState<TransactionFilters>({});
 
-  const transactionFilterFn: FilterFn<TData> = (row, columnId, filterValue: TransactionFilters) => {
-    const transaction = row.original as Transaction;
 
-    // Apply type filter
-    if (filterValue.types && filterValue.types.length > 0) {
-      if (!filterValue.types.includes(transaction.type)) {
-        return false;
-      }
-    }
+  const { sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
 
-    // Apply symbol filter
-    if (filterValue.symbols && filterValue.symbols.length > 0) {
-      if (!filterValue.symbols.includes(transaction.stockSymbol)) {
-        return false;
-      }
-    }
-
-    return true;
-  };
 
   /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table's useReactTable() returns functions that cannot be memoized safely */
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    onSortingChange: setSorting,
-    getSortedRowModel: getSortedRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    filterFns: {
-      transactionFilter: transactionFilterFn,
-    },
-    globalFilterFn: transactionFilterFn,
-    state: {
-      sorting,
-      globalFilter: filters,
-    },
-    onGlobalFilterChange: setFilters,
+
+
   });
+
+
+  const handlePageSize = (value: string) => {
+    setPageState({ page: 1, pageSize: Number(value) });
+  };
+
+  const handleNext = () => {
+    if (pageState?.page < totalPages) {
+      setPageState((prev: any) => ({ ...prev, page: prev.page + 1 }));
+    }
+  };
+
+  const handlePrev = () => {
+    if (pageState?.page > 1) {
+      setPageState((prev: any) => ({ ...prev, page: prev.page - 1 }));
+    }
+  };
 
   // Get current view transactions (filtered data)
   const currentViewTransactions = isLoading
@@ -102,7 +104,10 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       <div className="flex h-full min-h-0 flex-col rounded-lg border border-slate-700">
         <div className="shrink-0 rounded-t-lg border-b border-slate-700 bg-slate-800 px-2 py-2">
           <div className="flex flex-wrap items-center justify-start md:justify-end gap-2 w-full md:w-auto">
-            <DataTableFilters data={data as Transaction[]} onFilterChange={setFilters} activeFilters={filters} />
+            <DataTableFilters data={data as Transaction[]} onFilterChange={(newFilters: any) => {
+              setFilters(newFilters);
+              setPageState((prev: any) => ({ ...prev, page: 1 }));
+            }} activeFilters={filters} />
             {shouldShowMobileLayout !== undefined && onToggleView ? (
               <TableViewToggle
                 shouldShowMobileLayout={shouldShowMobileLayout}
@@ -126,7 +131,18 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id} className="sticky top-0 z-10 bg-slate-800 text-gray-100/90">
+                    <TableHead key={header.id}
+                      onClick={header.column.getCanSort() ? () => {
+                        setPageState((prev: any) => ({ ...prev, page: 1 }));
+                        if (sorting == null) {
+                          setSorting({ key: header.column.id, order: "asc" })
+                        } else if (sorting?.key === header.column.id) {
+                          setSorting((prev: any) => ({ key: header.column.id, order: prev.order === "desc" ? "asc" : "desc" }))
+                        } else {
+                          setSorting({ key: header.column.id, order: "asc" })
+                        }
+                      } : undefined}
+                      className="sticky top-0 z-10 bg-slate-800 text-gray-100/90">
                       {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
                     </TableHead>
                   );
@@ -195,6 +211,33 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
             )}
           </TableBody>
         </Table>
+        <div className="bg-slate-800  flex justify-between p-4">
+
+          <div className="">
+            <Select
+              value={String(pageState?.pageSize || 10)}
+              onValueChange={handlePageSize}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="10">10 rows</SelectItem>
+                <SelectItem value="20">20 rows</SelectItem>
+                <SelectItem value="40">40 rows</SelectItem>
+                <SelectItem value="50">50 rows</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex gap-3">
+            <Button onClick={handlePrev} disabled={!pageState || pageState.page <= 1}>Prev</Button>
+            <Button variant="outline" disabled>{pageState?.page || 1}</Button>
+            <Button onClick={handleNext} disabled={!pageState || !totalPages || pageState.page >= totalPages}>Next</Button>
+          </div>
+
+
+        </div>
       </div>
     </MotionConfig>
   );

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -59,7 +59,8 @@ interface DataTableProps<TData, TValue> {
   setFilters: (value: TransactionFilters) => void;
   sorting: { key: string, order: "asc" | "desc" } | null;
   setSorting: (value: { key: string, order: "asc" | "desc" } | null) => void
-  availableSymbols: { stockSymbol: string }[]
+  availableSymbols: { stockSymbol: string }[],
+  totalCount:number
 
 }
 
@@ -74,7 +75,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   "use no memo";
 
 
-  const { availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
+  const { totalCount,availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
 
 
   /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table's useReactTable() returns functions that cannot be memoized safely */
@@ -131,6 +132,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
             <TableToggleColumns table={table} className="ml-0 bg-slate-700 border-slate-600 hover:bg-slate-600" />
             <ExportTransactionsButton
               transactions={data as Transaction[]}
+              totalCount={totalCount}
               currentViewTransactions={currentViewTransactions}
               currentViewFilters={filters}
               disabled={isLoading}

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -33,7 +33,7 @@ import { Button } from "@/components/ui/button";
 const MotionTableRow = motion.create(TableRow);
 
 interface TransactionFilters {
-  types?: ("buy" | "sell" | "dividend")[];
+  types?: string[];
   symbols?: string[];
 }
 
@@ -53,13 +53,13 @@ interface DataTableProps<TData, TValue> {
   onToggleView?: (fullTable: boolean) => void;
   renderMobileSubRow?: (original: TData) => React.ReactNode;
   pageState: pageState;
-  setPageState: (value: pageState) => void;
+  setPageState: React.Dispatch<React.SetStateAction<pageState>>;
   totalPages: number;
   filters: TransactionFilters;
-  setFilters: (value: TransactionFilters) => void;
+  setFilters:  React.Dispatch<React.SetStateAction<TransactionFilters>>;
   sorting: { key: string, order: "asc" | "desc" } | null;
-  setSorting: (value: { key: string, order: "asc" | "desc" } | null) => void
-  availableSymbols: { stockSymbol: string }[],
+  setSorting: React.Dispatch<React.SetStateAction<{ key: string, order: "asc" | "desc" } | null>>;
+  availableSymbols: { stockSymbol: string }[]
   totalCount:number
 
 }
@@ -75,7 +75,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   "use no memo";
 
 
-  const { totalCount,availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
+  const {totalCount, availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props 
 
 
   /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table's useReactTable() returns functions that cannot be memoized safely */
@@ -95,13 +95,13 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
 
   const handleNext = () => {
     if (pageState?.page < totalPages) {
-      setPageState((prev: any) => ({ ...prev, page: prev.page + 1 }));
+      setPageState((prev) => ({ ...prev, page: prev.page + 1 }));
     }
   };
 
   const handlePrev = () => {
     if (pageState?.page > 1) {
-      setPageState((prev: any) => ({ ...prev, page: prev.page - 1 }));
+      setPageState((prev) => ({ ...prev, page: prev.page - 1 }));
     }
   };
 
@@ -118,9 +118,9 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
             <DataTableFilters
               data={data as Transaction[]}
               availableSymbols={availableSymbols?.map((val: { stockSymbol: string }) => val.stockSymbol)}
-              onFilterChange={(newFilters: any) => {
+              onFilterChange={(newFilters) => {
                 setFilters(newFilters);
-                setPageState((prev: any) => ({ ...prev, page: 1 }));
+                setPageState((prev) => ({ ...prev, page: 1 }));
               }} activeFilters={filters} />
             {shouldShowMobileLayout !== undefined && onToggleView ? (
               <TableViewToggle
@@ -148,11 +148,11 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
                   return (
                     <TableHead key={header.id}
                       onClick={header.column.getCanSort() ? () => {
-                        setPageState((prev: any) => ({ ...prev, page: 1 }));
+                        setPageState((prev) => ({ ...prev, page: 1 }));
                         if (sorting == null) {
                           setSorting({ key: header.column.id, order: "asc" })
                         } else if (sorting?.key === header.column.id) {
-                          setSorting((prev: any) => ({ key: header.column.id, order: prev.order === "desc" ? "asc" : "desc" }))
+                          setSorting((prev) => ({ key: header.column.id, order: prev?.order === "desc" ? "asc" : "desc" }))
                         } else {
                           setSorting({ key: header.column.id, order: "asc" })
                         }

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -57,8 +57,10 @@ interface DataTableProps<TData, TValue> {
   totalPages: number;
   filters: TransactionFilters;
   setFilters: (value: TransactionFilters) => void;
-  sorting: { key: string; order: "asc" | "desc" } | null;
-  setSorting: (value: { key: string; order: "asc" | "desc" } | null) => void
+  sorting: { key: string, order: "asc" | "desc" } | null;
+  setSorting: (value: { key: string, order: "asc" | "desc" } | null) => void
+  availableSymbols: { stockSymbol: string }[]
+
 }
 
 
@@ -72,7 +74,7 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
   "use no memo";
 
 
-  const { sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
+  const { availableSymbols, sorting, setSorting, setFilters, filters, pageState, setPageState, totalPages, columns, data, isLoading = false, shouldShowMobileLayout, onToggleView, renderMobileSubRow } = props as any;
 
 
   /* eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table's useReactTable() returns functions that cannot be memoized safely */
@@ -112,10 +114,13 @@ export function DataTable<TData, TValue>(props: DataTableProps<TData, TValue>) {
       <div className="flex h-full min-h-0 flex-col rounded-lg border border-slate-700">
         <div className="shrink-0 rounded-t-lg border-b border-slate-700 bg-slate-800 px-2 py-2">
           <div className="flex flex-wrap items-center justify-start md:justify-end gap-2 w-full md:w-auto">
-            <DataTableFilters data={data as Transaction[]} onFilterChange={(newFilters: any) => {
-              setFilters(newFilters);
-              setPageState((prev: any) => ({ ...prev, page: 1 }));
-            }} activeFilters={filters} />
+            <DataTableFilters
+              data={data as Transaction[]}
+              availableSymbols={availableSymbols?.map((val: { stockSymbol: string }) => val.stockSymbol)}
+              onFilterChange={(newFilters: any) => {
+                setFilters(newFilters);
+                setPageState((prev: any) => ({ ...prev, page: 1 }));
+              }} activeFilters={filters} />
             {shouldShowMobileLayout !== undefined && onToggleView ? (
               <TableViewToggle
                 shouldShowMobileLayout={shouldShowMobileLayout}

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTable.tsx
@@ -37,6 +37,14 @@ interface TransactionFilters {
   symbols?: string[];
 }
 
+
+interface pageState {
+  page: number,
+  pageSize: number
+
+}
+
+
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
@@ -44,13 +52,13 @@ interface DataTableProps<TData, TValue> {
   shouldShowMobileLayout?: boolean;
   onToggleView?: (fullTable: boolean) => void;
   renderMobileSubRow?: (original: TData) => React.ReactNode;
-  pageState: any;
-  setPageState?: any;
-  totalPages?: number;
-  filters?: TransactionFilters;
-  setFilters?: any;
-  sorting?: { key: string; order: string } | null;
-  setSorting?: any;
+  pageState: pageState;
+  setPageState: (value: pageState) => void;
+  totalPages: number;
+  filters: TransactionFilters;
+  setFilters: (value: TransactionFilters) => void;
+  sorting: { key: string; order: "asc" | "desc" } | null;
+  setSorting: (value: { key: string; order: "asc" | "desc" } | null) => void
 }
 
 

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTableFilters.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/DataTableFilters.tsx
@@ -20,9 +20,10 @@ interface DataTableFiltersProps {
     types?: string[];
     symbols?: string[];
   };
+  availableSymbols: string[]
 }
 
-export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTableFiltersProps) {
+export function DataTableFilters({ data, onFilterChange, activeFilters, availableSymbols }: DataTableFiltersProps) {
   // State for dropdown open/close
   const [isOpen, setIsOpen] = useState(false);
 
@@ -47,7 +48,7 @@ export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTa
   })();
 
   // Extract unique stock symbols from data
-  const stockSymbols = (() => {
+  const stockSymbol = (() => {
     const symbols = new Set<string>();
     data.forEach((transaction) => {
       symbols.add(transaction.stockSymbol);
@@ -55,6 +56,7 @@ export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTa
     return Array.from(symbols).sort();
   })();
 
+  const stockSymbols = availableSymbols ?? stockSymbol
   const toggleTypeFilter = (type: string) => {
     const currentTypes = pendingFilters.types || [];
     const newTypes = currentTypes.includes(type) ? currentTypes.filter((t) => t !== type) : [...currentTypes, type];
@@ -131,7 +133,7 @@ export function DataTableFilters({ data, onFilterChange, activeFilters }: DataTa
 
           <DropdownMenuLabel>Stock Symbol</DropdownMenuLabel>
           <div className="max-h-[200px] overflow-y-auto">
-            {stockSymbols.map((symbol) => (
+            {stockSymbols?.map((symbol) => (
               <DropdownMenuCheckboxItem
                 key={`symbol-${symbol}`}
                 checked={pendingFilters.symbols?.includes(symbol)}

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/columns.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/components/columns.tsx
@@ -136,6 +136,7 @@ export const getTransactionsTableDesktopColumns = (
 
       return <div className={getProfitLossColorClass(changePct)}>{formatSignedPercentage(changePct)}</div>;
     },
+     enableSorting: false,
   },
   {
     accessorKey: "totalValue",
@@ -145,6 +146,7 @@ export const getTransactionsTableDesktopColumns = (
       const totalValue = calculateTotalValue(row.original);
       return <div>{formatCurrency(totalValue)}</div>;
     },
+    enableSorting: false, 
   },
   {
     accessorKey: "commissionAndTaxes",
@@ -154,6 +156,7 @@ export const getTransactionsTableDesktopColumns = (
       const value = calculateCommissionAndTaxes(row.original);
       return value ? <div>{formatCurrency(value)}</div> : <div>-</div>;
     },
+    enableSorting: false, 
   },
   {
     id: "actions",

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -41,7 +41,7 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
   const [filters, setFilters] = React.useState<TransactionFilters>({});
   const [sorting, setSorting] = React.useState<{ key: string, order: "asc" | "desc" } | null>(null);
 
-  const { transactions } = useTransactions(portfolioId, pageState.page, pageState.pageSize, filters, sorting);
+  const { transactions } = useTransactions(portfolioId, pageState.page, pageState.pageSize, filters, sorting, true);
   const totalPages = transactions?.data?.totalPages ?? 0;
   const totalCount=transactions?.data?.totalCount ?? 0
   const pricesQuery = useQuery({

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -21,7 +21,7 @@ interface TransactionsTableProps {
 }
 
 interface TransactionFilters {
-  types?: ("buy" | "sell" | "dividend")[];
+  types?: string[];
   symbols?: string[];
 }
 

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -6,7 +6,7 @@ import useBreakpoint from "@/utils/hooks/useBreakpoints";
 import { useTransactions } from "@/utils/hooks/useTransactionData";
 import { useQuery } from "@tanstack/react-query";
 import dynamic from "next/dynamic";
-import React from "react";
+import React, { useState } from "react";
 import { DataTable } from "./components/DataTable";
 import {
   getChangeSinceTransactionPct,
@@ -20,6 +20,11 @@ interface TransactionsTableProps {
   portfolioId: number;
 }
 
+interface TransactionFilters {
+  types?: ("buy" | "sell" | "dividend")[];
+  symbols?: string[];
+}
+
 export const TransactionsTable = (props: TransactionsTableProps) => {
   const { portfolioId } = props;
 
@@ -28,7 +33,17 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
 
   const [shouldShowFullTable, setShouldShowFullTable] = React.useState(!shouldShowMobileLayout);
 
-  const { transactions } = useTransactions(portfolioId);
+  const [pageState, setPageState] = useState({
+    page: 1,
+    pageSize: 10,
+  });
+
+  const [filters, setFilters] = React.useState<TransactionFilters>({});
+  const [sorting, setSorting] = React.useState<{ key: string; order: string } | null>(null);
+
+  const { transactions } = useTransactions(portfolioId, pageState.page, pageState.pageSize, filters, sorting);
+  const totalPages = transactions?.data?.totalPages;
+
   const pricesQuery = useQuery({
     ...stockPriceQueries.latestAll(),
     select: (data) => {
@@ -45,7 +60,7 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
   };
 
   const pricesBySymbol = pricesQuery.data ?? {};
-  const allTransactions = (transactions.data as Transaction[]) || [];
+  const allTransactions = transactions.data?.items || [];
   const columns = shouldShowFullTable
     ? getTransactionsTableDesktopColumns(pricesBySymbol)
     : getTransactionsTableMobileColumns();
@@ -82,6 +97,13 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
         shouldShowMobileLayout={!shouldShowFullTable}
         onToggleView={handleToggle}
         renderMobileSubRow={!shouldShowFullTable ? renderMobileSubRow : undefined}
+        pageState={pageState}
+        setPageState={setPageState}
+        totalPages={totalPages}
+        filters={filters}
+        setFilters={setFilters}
+        sorting={sorting}
+        setSorting={setSorting}
       />
     </>
   );

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -39,11 +39,10 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
   });
 
   const [filters, setFilters] = React.useState<TransactionFilters>({});
-  const [sorting, setSorting] = React.useState<{ key: string; order: string } | null>(null);
+  const [sorting, setSorting] = React.useState<{ key: string, order: "asc" | "desc" } | null>(null);
 
   const { transactions } = useTransactions(portfolioId, pageState.page, pageState.pageSize, filters, sorting);
-  const totalPages = transactions?.data?.totalPages;
-
+  const totalPages = transactions?.data?.totalPages ?? 0;
   const pricesQuery = useQuery({
     ...stockPriceQueries.latestAll(),
     select: (data) => {
@@ -104,6 +103,8 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
         setFilters={setFilters}
         sorting={sorting}
         setSorting={setSorting}
+        availableSymbols={transactions.data?.availableSymbols ?? []}
+
       />
     </>
   );

--- a/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionsTable/index.tsx
@@ -43,6 +43,7 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
 
   const { transactions } = useTransactions(portfolioId, pageState.page, pageState.pageSize, filters, sorting);
   const totalPages = transactions?.data?.totalPages ?? 0;
+  const totalCount=transactions?.data?.totalCount ?? 0
   const pricesQuery = useQuery({
     ...stockPriceQueries.latestAll(),
     select: (data) => {
@@ -102,6 +103,7 @@ export const TransactionsTable = (props: TransactionsTableProps) => {
         filters={filters}
         setFilters={setFilters}
         sorting={sorting}
+        totalCount={totalCount}
         setSorting={setSorting}
         availableSymbols={transactions.data?.availableSymbols ?? []}
 

--- a/src/components/molecules/ExportTransactionsButton/index.tsx
+++ b/src/components/molecules/ExportTransactionsButton/index.tsx
@@ -43,15 +43,17 @@ export function ExportTransactionsButton({
   const params = useParams();
   const portfolioId = Number(params.portfolioId)
 
-  const { AllTransactions } = useTransactions(portfolioId)
-
-  const handleExportAll = async () => {
-    const result = await AllTransactions.refetch()
-    const data = result.data?.items
-    const csvContent = exportTransactionsToCSV(data ?? transactions);
-    const filename = generateExportFilename(false, data?.length ?? transactions?.length);
+  const { AllTransactions } = useTransactions(portfolioId,1,10,currentViewFilters)
+ const handleExportAll = async () => {
+    
+    const result = await AllTransactions.refetch();
+    const data = result.data?.items;
+    if(!data) return 
+    const csvContent = exportTransactionsToCSV(data);
+    const filename = generateExportFilename(false, data.length);
     downloadCSV(csvContent, filename);
-  };
+ 
+};
 
 
 

--- a/src/components/molecules/ExportTransactionsButton/index.tsx
+++ b/src/components/molecules/ExportTransactionsButton/index.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/utils/helpers/exportTransactionsHelpers";
 import { Download, FileDown } from "lucide-react";
 import React from "react";
+import { useParams } from "next/navigation";
+import { useTransactions } from "@/utils/hooks/useTransactionData";
 
 interface ExportTransactionsButtonProps {
   transactions: Transaction[];
@@ -27,20 +29,31 @@ interface ExportTransactionsButtonProps {
   };
   disabled?: boolean;
   className?: string;
+  totalCount: number,
 }
 
 export function ExportTransactionsButton({
   transactions,
   currentViewTransactions,
   currentViewFilters,
+  totalCount,
   disabled = false,
   className,
 }: ExportTransactionsButtonProps) {
-  const handleExportAll = () => {
-    const csvContent = exportTransactionsToCSV(transactions);
-    const filename = generateExportFilename(false, transactions.length);
+  const params = useParams();
+  const portfolioId = Number(params.portfolioId)
+
+  const { AllTransactions } = useTransactions(portfolioId)
+
+  const handleExportAll = async () => {
+    const result = await AllTransactions.refetch()
+    const data = result.data?.items
+    const csvContent = exportTransactionsToCSV(data ?? transactions);
+    const filename = generateExportFilename(false, data?.length ?? transactions?.length);
     downloadCSV(csvContent, filename);
   };
+
+
 
   const handleExportCurrentView = () => {
     if (!currentViewTransactions) return;
@@ -73,7 +86,7 @@ export function ExportTransactionsButton({
         <DropdownMenuItem onClick={handleExportAll}>
           <FileDown className="h-4 w-4 mr-2" />
           Export All Transactions
-          <span className="ml-auto text-xs text-gray-300">({transactions.length} records)</span>
+          <span className="ml-auto text-xs text-gray-300">({totalCount} records)</span>
         </DropdownMenuItem>
 
         {hasCurrentView && (

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -77,6 +77,7 @@ const MotionButton = motion.create(Button);
 const TableHeaderCell = ({ column, heading }: { column: any; heading: string }) => {
   "use no memo";
   const sortDirection = column.getIsSorted();
+  const canSort = column.getCanSort();
 
   // Function to get the appropriate icon
   const getSortIcon = () => {
@@ -90,6 +91,14 @@ const TableHeaderCell = ({ column, heading }: { column: any; heading: string }) 
     }
   };
   const isAscending = sortDirection === "asc";
+
+  if (!canSort) {
+    return (
+      <div className="pl-2 -ml-[0.7rem] relative h-10 flex items-center">
+        <p className="text-gray-100 font-semibold text-left mr-2">{heading}</p>
+      </div>
+    );
+  }
 
   return (
     <MotionButton

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -33,6 +33,9 @@ export const useTransactions = (
           page: number;
           pageSize: number;
           totalPages: number;
+          availableSymbols:{stockSymbol:string}[]
+
+          
         };
       }
       throw new Error(result.message);

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -18,7 +18,7 @@ export const useTransactions = (
   portfolioId: number,
   page: number = 1,
   pageSize: number = 10,
-  filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+  filters?: { types?: string[]; symbols?: string[] },
   sorting?: { key: string; order: string } | null
 ) => {
   const queryClient = useQueryClient();

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -13,15 +13,27 @@ import { Transaction, TransactionSchemaType } from "@/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { handleServerPromise } from "../helpers";
 
-export const useTransactions = (portfolioId: number) => {
+export const useTransactions = (
+  portfolioId: number,
+  page: number = 1,
+  pageSize: number = 10,
+  filters?: { types?: ("buy" | "sell" | "dividend")[]; symbols?: string[] },
+  sorting?: { key: string; order: string } | null
+) => {
   const queryClient = useQueryClient();
 
   const transactions = useQuery({
-    queryKey: ["transactions", portfolioId],
+    queryKey: ["transactions", portfolioId, page, pageSize, filters, sorting],
     queryFn: async () => {
-      const result = await getTransactions(portfolioId);
+      const result = await getTransactions(portfolioId, page, pageSize, filters, sorting );
       if (result.success) {
-        return result.data as unknown as Transaction[];
+        return result.data as unknown as {
+          items: Transaction[];
+          totalCount: number;
+          page: number;
+          pageSize: number;
+          totalPages: number;
+        };
       }
       throw new Error(result.message);
     },

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -19,7 +19,8 @@ export const useTransactions = (
   page: number = 1,
   pageSize: number = 10,
   filters?: { types?: string[]; symbols?: string[] },
-  sorting?: { key: string; order: string } | null
+  sorting?: { key: string; order: string } | null,
+  fetchPaginated: boolean = false
 ) => {
   const queryClient = useQueryClient();
 
@@ -36,25 +37,28 @@ export const useTransactions = (
           totalPages: number;
           availableSymbols:{stockSymbol:string}[]
 
-          
+
         };
       }
       throw new Error(result.message);
     },
-    enabled: !!portfolioId,
+    enabled: !!portfolioId && fetchPaginated,
     staleTime: 5 * 60 * 1000, // 5 minutes - data is considered fresh for 5 minutes
   });
 
   const AllTransactions = useQuery({
-    queryKey: ["transactions", portfolioId,"all"],
+    queryKey: ["transactions", portfolioId, "all"],
     queryFn: async () => {
-      const result = await getAllTransactions(portfolioId);
+      const result = await getAllTransactions(portfolioId,filters);
       if (result.success) {
         return result.data as unknown as {
-          items: Transaction[]  
-        };
+          items: Transaction[]
+        }
+      } else {
+        toast({ title: result.message || "An error occurred", type: "error" });
+        return
+
       }
-      throw new Error(result.message);
     },
     enabled: false,
   });

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -6,6 +6,7 @@ import {
   deleteTransaction,
   editTransaction,
   getTransactions,
+  getAllTransactions
 } from "@/actions/transaction/TransactionFunctions";
 import { historicalReturnsQueries } from "@/features/historicalReturns/queries";
 import { toast } from "@/components/molecules/Toast";
@@ -42,6 +43,20 @@ export const useTransactions = (
     },
     enabled: !!portfolioId,
     staleTime: 5 * 60 * 1000, // 5 minutes - data is considered fresh for 5 minutes
+  });
+
+  const AllTransactions = useQuery({
+    queryKey: ["transactions", portfolioId,"all"],
+    queryFn: async () => {
+      const result = await getAllTransactions(portfolioId);
+      if (result.success) {
+        return result.data as unknown as {
+          items: Transaction[]  
+        };
+      }
+      throw new Error(result.message);
+    },
+    enabled: false,
   });
 
   const invalidateQueries = () => {
@@ -116,6 +131,7 @@ export const useTransactions = (
   });
 
   return {
+    AllTransactions,
     transactions,
     createTransaction: createTransactionMutation,
     createMultipleTransactions: createMultipleTransactionsMutation,

--- a/src/utils/hooks/useTransactionData.ts
+++ b/src/utils/hooks/useTransactionData.ts
@@ -47,7 +47,7 @@ export const useTransactions = (
   });
 
   const AllTransactions = useQuery({
-    queryKey: ["transactions", portfolioId, "all"],
+    queryKey: ["transactions", portfolioId, "all",filters],
     queryFn: async () => {
       const result = await getAllTransactions(portfolioId,filters);
       if (result.success) {
@@ -56,7 +56,7 @@ export const useTransactions = (
         }
       } else {
         toast({ title: result.message || "An error occurred", type: "error" });
-        return
+        return null
 
       }
     },


### PR DESCRIPTION
## What changed

In this pr i have implimented seperate server function  for geting all transcations when user click on the export button,

## Why

the purpose of this change is this pr https://github.com/Wajahat43/psxworth/pull/37
in  this pr i implimented server side pagination ,due to this change,  the export functionliy effected and it only exporting records that are currently on the page.
This pr fixes that.
Closes #11

## Testing

## before

https://github.com/user-attachments/assets/d18dc3c2-55c1-4f9e-a792-124c07f161b5

## after


https://github.com/user-attachments/assets/d392f85a-e6da-4383-b0da-9f5157cca8fd




## Checklist

- [x] PR targets `develop` (not `main`)
- [x] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint:types` pass locally


"Note : This PR is branched off my previous unmerged pagination branch. The file diff looks large right now, but it will shrink automatically down to just the second fix once my first PR is merged into develop."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transactions are now paginated with page-size selection and Prev/Next controls.
  * Added external filtering by transaction type and stock symbol, plus an available-symbols list.
  * Added column sorting controls (some columns intentionally non-sortable).
  * Export now supports exporting all transactions and shows total record counts.

* **UX**
  * Table headers and filter controls now reflect externally controlled pagination, filters, and sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->