### PR TITLE
fix: resolve mobile sidebar Manage Account click issue

### DIFF
--- a/src/components/animate-ui/components/radix/sidebar.tsx
+++ b/src/components/animate-ui/components/radix/sidebar.tsx
@@ -185,7 +185,7 @@ function Sidebar({
 
   if (isMobile) {
     return (
-      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+      <Sheet  modal={false} open={openMobile} onOpenChange={setOpenMobile} {...props}>
         <SheetContent
           data-sidebar="sidebar"
           data-slot="sidebar"


### PR DESCRIPTION
## What changed

Fixed an issue in the mobile sidebar where interactive actions like “Manage Account” and Sign Out were not working due to Radix Sheet default modal behavior. Updated the Sheet configuration by setting `modal={false}`, which restored proper click and interaction handling inside the sidebar.


## Why

The default `modal={true}` behavior of Radix Sheet was blocking pointer events and interfering with interactive elements inside the sidebar. Because of this, buttons inside the sidebar were not responding correctly on mobile.

Switching to `modal={false}` ensures the sidebar behaves as a non-blocking navigation panel instead of a strict modal, which makes all actions fully clickable and usable.

Closes #39 



## Testing

- Tested manually on mobile viewport
- Verified “Manage Account” and sign-out buttons are clickable and working
- Checked sidebar open/close behavior (including ESC and outside click)
- Ensured no regression in desktop sidebar behavior



## Screenshots / video (UI changes only)

  

https://github.com/user-attachments/assets/b4882734-1b2d-4d10-a17f-5488b884184c




## Checklist

- [x] PR targets `develop` (not `main`)
- [x] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint:types` pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified mobile sidebar sheet modal behavior to improve user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->