### PR TITLE
feat: add user settings management and portfolio tax configuration

### DIFF
--- a/migrations-userdb/0001_careful_firelord.sql
+++ b/migrations-userdb/0001_careful_firelord.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "userSettingsTable" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"tax_status" text DEFAULT 'filer' NOT NULL,
+	"commission_rate" real DEFAULT 0 NOT NULL,
+	"is_commission_percentage" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/migrations-userdb/0001_careful_firelord.sql
+++ b/migrations-userdb/0001_careful_firelord.sql
@@ -1,6 +1,6 @@
 CREATE TABLE "userSettingsTable" (
 	"user_id" text PRIMARY KEY NOT NULL,
-	"tax_status" text DEFAULT 'filer' NOT NULL,
+	"tax_status" text DEFAULT 'filer' NOT NULL CHECK ("tax_status" IN ('filer', 'non-filer')),
 	"commission_rate" real DEFAULT 0 NOT NULL,
 	"is_commission_percentage" boolean DEFAULT true NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/migrations-userdb/0002_unusual_famine.sql
+++ b/migrations-userdb/0002_unusual_famine.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "portfolioTable" ADD COLUMN "use_global_tax" boolean DEFAULT true NOT NULL;--> statement-breakpoint
+ALTER TABLE "portfolioTable" ADD COLUMN "tax_status" text DEFAULT 'filer' NOT NULL;

--- a/migrations-userdb/0002_unusual_famine.sql
+++ b/migrations-userdb/0002_unusual_famine.sql
@@ -1,2 +1,2 @@
 ALTER TABLE "portfolioTable" ADD COLUMN "use_global_tax" boolean DEFAULT true NOT NULL;--> statement-breakpoint
-ALTER TABLE "portfolioTable" ADD COLUMN "tax_status" text DEFAULT 'filer' NOT NULL;
+ALTER TABLE "portfolioTable" ADD COLUMN "tax_status" text DEFAULT 'filer' NOT NULL CHECK ("tax_status" IN ('filer', 'non-filer'));

--- a/migrations-userdb/meta/0001_snapshot.json
+++ b/migrations-userdb/meta/0001_snapshot.json
@@ -1,0 +1,406 @@
+{
+  "id": "ccbaae95-b6fc-4de6-a316-77a29797826d",
+  "prevId": "57e6bee5-b1db-495a-a670-c505b2e1d228",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.portfolioTable": {
+      "name": "portfolioTable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "portfolioTable_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stockPerformance": {
+      "name": "stockPerformance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "stockPerformance_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_symbol": {
+          "name": "stock_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_cost": {
+          "name": "average_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_shares": {
+          "name": "total_shares",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dividends": {
+          "name": "total_dividends",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "realized_profit": {
+          "name": "realized_profit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tax_and_broker_fee": {
+          "name": "tax_and_broker_fee",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_inflow": {
+          "name": "total_inflow",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_outflow": {
+          "name": "total_outflow",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stockPerformance_portfolio_id_portfolioTable_id_fk": {
+          "name": "stockPerformance_portfolio_id_portfolioTable_id_fk",
+          "tableFrom": "stockPerformance",
+          "tableTo": "portfolioTable",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stockPerformance_portfolio_id_stock_symbol_unique": {
+          "name": "stockPerformance_portfolio_id_stock_symbol_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "portfolio_id",
+            "stock_symbol"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactionTable": {
+      "name": "transactionTable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "transactionTable_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_date": {
+          "name": "transaction_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_symbol": {
+          "name": "stock_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_shares": {
+          "name": "number_of_shares",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_share": {
+          "name": "price_per_share",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dividend_per_share": {
+          "name": "dividend_per_share",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_and_taxes": {
+          "name": "commission_and_taxes",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_commission_percentage": {
+          "name": "is_commission_percentage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactionTable_portfolio_id_portfolioTable_id_fk": {
+          "name": "transactionTable_portfolio_id_portfolioTable_id_fk",
+          "tableFrom": "transactionTable",
+          "tableTo": "portfolioTable",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSettingsTable": {
+      "name": "userSettingsTable",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tax_status": {
+          "name": "tax_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filer'"
+        },
+        "commission_rate": {
+          "name": "commission_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_commission_percentage": {
+          "name": "is_commission_percentage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations-userdb/meta/0002_snapshot.json
+++ b/migrations-userdb/meta/0002_snapshot.json
@@ -1,0 +1,420 @@
+{
+  "id": "330ec81e-8d64-4240-bbb2-89d338e5f560",
+  "prevId": "ccbaae95-b6fc-4de6-a316-77a29797826d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.portfolioTable": {
+      "name": "portfolioTable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "portfolioTable_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "use_global_tax": {
+          "name": "use_global_tax",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tax_status": {
+          "name": "tax_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stockPerformance": {
+      "name": "stockPerformance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "stockPerformance_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_symbol": {
+          "name": "stock_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "average_cost": {
+          "name": "average_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_shares": {
+          "name": "total_shares",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dividends": {
+          "name": "total_dividends",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "realized_profit": {
+          "name": "realized_profit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tax_and_broker_fee": {
+          "name": "tax_and_broker_fee",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_inflow": {
+          "name": "total_inflow",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_outflow": {
+          "name": "total_outflow",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stockPerformance_portfolio_id_portfolioTable_id_fk": {
+          "name": "stockPerformance_portfolio_id_portfolioTable_id_fk",
+          "tableFrom": "stockPerformance",
+          "tableTo": "portfolioTable",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stockPerformance_portfolio_id_stock_symbol_unique": {
+          "name": "stockPerformance_portfolio_id_stock_symbol_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "portfolio_id",
+            "stock_symbol"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactionTable": {
+      "name": "transactionTable",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "transactionTable_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "portfolio_id": {
+          "name": "portfolio_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_date": {
+          "name": "transaction_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_symbol": {
+          "name": "stock_symbol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_of_shares": {
+          "name": "number_of_shares",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_share": {
+          "name": "price_per_share",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dividend_per_share": {
+          "name": "dividend_per_share",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commission_and_taxes": {
+          "name": "commission_and_taxes",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_commission_percentage": {
+          "name": "is_commission_percentage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactionTable_portfolio_id_portfolioTable_id_fk": {
+          "name": "transactionTable_portfolio_id_portfolioTable_id_fk",
+          "tableFrom": "transactionTable",
+          "tableTo": "portfolioTable",
+          "columnsFrom": [
+            "portfolio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSettingsTable": {
+      "name": "userSettingsTable",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tax_status": {
+          "name": "tax_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filer'"
+        },
+        "commission_rate": {
+          "name": "commission_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_commission_percentage": {
+          "name": "is_commission_percentage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations-userdb/meta/_journal.json
+++ b/migrations-userdb/meta/_journal.json
@@ -8,6 +8,20 @@
       "when": 1771755807023,
       "tag": "0000_smart_rhodey",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1780728780983,
+      "tag": "0001_careful_firelord",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780730356470,
+      "tag": "0002_unusual_famine",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/portfolio/portfolioActions.ts
+++ b/src/actions/portfolio/portfolioActions.ts
@@ -66,7 +66,7 @@ export const getPortfolios = withErrorHandling(async () => {
     async (id: string) => {
       return db.select().from(portfolioTable).where(eq(portfolioTable.userId, id));
     },
-    [`user-portfolios`],
+    ["user-portfolios", userId],
     {
       tags: [`user-${userId}-portfolios`],
       revalidate: 10,

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -15,7 +15,7 @@ import { Transaction, TransactionSchemaType } from "@/types";
 import { MULTIPLE_TRANSACTIONS_CREATED, TRANSACTION_CREATED, TRANSACTION_DELETED } from "@/utils/posthog/events";
 import { generateObject } from "ai";
 import "dotenv/config";
-import { asc, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { unstable_cache, updateTag } from "next/cache";
 import { createResponse } from "../utils";
 import { requireAuth, withPortfolioOwnership, withErrorHandling } from "../utils/middleware";
@@ -25,37 +25,40 @@ export const createTransactionServer = withErrorHandling(async (transactionData:
   const userId = await requireAuth();
   await withPortfolioOwnership(transactionData.portfolioId, userId);
 
-  // Fetch portfolio settings
+  // Fetch portfolio settings scoped to user for security
   const portfolio = await db
     .select()
     .from(portfolioTable)
-    .where(eq(portfolioTable.id, transactionData.portfolioId))
+    .where(and(eq(portfolioTable.id, transactionData.portfolioId), eq(portfolioTable.userId, userId)))
     .limit(1)
     .then((rows) => rows[0]);
+
+  // Query settings once and use local defaults if not found
+  let settings = await db
+    .select()
+    .from(userSettingsTable)
+    .where(eq(userSettingsTable.userId, userId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!settings) {
+    settings = {
+      userId,
+      taxStatus: "filer" as const,
+      commissionRate: 0.15,
+      isCommissionPercentage: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  }
 
   // Determine the effective tax status (local vs global)
   let effectiveTaxStatus: "filer" | "non-filer" = "filer";
   if (portfolio && !portfolio.useGlobalTax) {
     effectiveTaxStatus = portfolio.taxStatus;
   } else {
-    const settings = await db
-      .select()
-      .from(userSettingsTable)
-      .where(eq(userSettingsTable.userId, userId))
-      .limit(1)
-      .then((rows) => rows[0]);
-    if (settings) {
-      effectiveTaxStatus = settings.taxStatus;
-    }
+    effectiveTaxStatus = settings.taxStatus;
   }
-
-  // Cross-reference user settings for commission rules
-  const settings = await db
-    .select()
-    .from(userSettingsTable)
-    .where(eq(userSettingsTable.userId, userId))
-    .limit(1)
-    .then((rows) => rows[0]);
 
   if (transactionData.type === "dividend") {
     if (
@@ -72,10 +75,8 @@ export const createTransactionServer = withErrorHandling(async (transactionData:
       transactionData.commissionAndTaxes === null ||
       transactionData.commissionAndTaxes === 0
     ) {
-      if (settings) {
-        transactionData.commissionAndTaxes = settings.commissionRate;
-        transactionData.isCommissionPercentage = settings.isCommissionPercentage;
-      }
+      transactionData.commissionAndTaxes = settings.commissionRate;
+      transactionData.isCommissionPercentage = settings.isCommissionPercentage;
     }
   }
 
@@ -101,44 +102,54 @@ export const createTransactionServer = withErrorHandling(async (transactionData:
 });
 
 export const createMultipleTransactions = withErrorHandling(async (transactions: TransactionSchemaType[]) => {
-  const userId = await requireAuth();
-  await withPortfolioOwnership(transactions[0].portfolioId, userId);
-
   if (!transactions || transactions.length === 0) {
     throw new Error("No transactions provided");
   }
 
-  // Fetch portfolio settings
+  const userId = await requireAuth();
+  
+  const uniquePortfolioIds = new Set(transactions.map((t) => t.portfolioId));
+  if (uniquePortfolioIds.size !== 1) {
+    throw new Error("All transactions in a batch must belong to the same portfolio");
+  }
+
+  const portfolioId = transactions[0].portfolioId;
+  await withPortfolioOwnership(portfolioId, userId);
+
+  // Fetch portfolio settings scoped to user for security
   const portfolio = await db
     .select()
     .from(portfolioTable)
-    .where(eq(portfolioTable.id, transactions[0].portfolioId))
+    .where(and(eq(portfolioTable.id, portfolioId), eq(portfolioTable.userId, userId)))
     .limit(1)
     .then((rows) => rows[0]);
+
+  // Query settings once and use local defaults if not found
+  let settings = await db
+    .select()
+    .from(userSettingsTable)
+    .where(eq(userSettingsTable.userId, userId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (!settings) {
+    settings = {
+      userId,
+      taxStatus: "filer" as const,
+      commissionRate: 0.15,
+      isCommissionPercentage: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  }
 
   // Determine the effective tax status (local vs global)
   let effectiveTaxStatus: "filer" | "non-filer" = "filer";
   if (portfolio && !portfolio.useGlobalTax) {
     effectiveTaxStatus = portfolio.taxStatus;
   } else {
-    const settings = await db
-      .select()
-      .from(userSettingsTable)
-      .where(eq(userSettingsTable.userId, userId))
-      .limit(1)
-      .then((rows) => rows[0]);
-    if (settings) {
-      effectiveTaxStatus = settings.taxStatus;
-    }
+    effectiveTaxStatus = settings.taxStatus;
   }
-
-  // Cross-reference user settings for commission rules
-  const settings = await db
-    .select()
-    .from(userSettingsTable)
-    .where(eq(userSettingsTable.userId, userId))
-    .limit(1)
-    .then((rows) => rows[0]);
 
   transactions.forEach((transactionData) => {
     if (transactionData.type === "dividend") {
@@ -156,15 +167,12 @@ export const createMultipleTransactions = withErrorHandling(async (transactions:
         transactionData.commissionAndTaxes === null ||
         transactionData.commissionAndTaxes === 0
       ) {
-        if (settings) {
-          transactionData.commissionAndTaxes = settings.commissionRate;
-          transactionData.isCommissionPercentage = settings.isCommissionPercentage;
-        }
+        transactionData.commissionAndTaxes = settings.commissionRate;
+        transactionData.isCommissionPercentage = settings.isCommissionPercentage;
       }
     }
   });
 
-  const portfolioId = transactions[0].portfolioId;
   const sortedTransactions = sortTransactionsByDateAndType(transactions);
   await db.transaction(async (tx) => {
     const formattedTransactions = sortedTransactions.map((t) => ({

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -21,19 +21,35 @@ import { createResponse } from "../utils";
 import { requireAuth, withPortfolioOwnership, withErrorHandling } from "../utils/middleware";
 import { sortTransactionsByDateAndType } from "./helpers";
 
-export const createTransactionServer = withErrorHandling(async (transactionData: TransactionSchemaType) => {
-  const userId = await requireAuth();
-  await withPortfolioOwnership(transactionData.portfolioId, userId);
-
+/**
+ * Fetches the user's global settings and the portfolio's tax override, then
+ * mutates each item in-place to fill in missing commissionAndTaxes /
+ * isCommissionPercentage values using the effective tax rules.
+ *
+ * Dividend tax rates (percentage of gross dividend):
+ *   - Filer:     15 %
+ *   - Non-filer: 30 %
+ *
+ * Buy / Sell commissions default to the user's saved commissionRate setting.
+ *
+ * @param userId      - Authenticated user ID (already verified by the caller).
+ * @param portfolioId - Portfolio that owns the transactions.
+ * @param items       - Transaction payloads to mutate in-place.
+ */
+async function applySettingsDefaults(
+  userId: string,
+  portfolioId: number,
+  items: TransactionSchemaType[]
+): Promise<void> {
   // Fetch portfolio settings scoped to user for security
   const portfolio = await db
     .select()
     .from(portfolioTable)
-    .where(and(eq(portfolioTable.id, transactionData.portfolioId), eq(portfolioTable.userId, userId)))
+    .where(and(eq(portfolioTable.id, portfolioId), eq(portfolioTable.userId, userId)))
     .limit(1)
     .then((rows) => rows[0]);
 
-  // Query settings once and use local defaults if not found
+  // Query settings once and fall back to safe defaults if not found
   let settings = await db
     .select()
     .from(userSettingsTable)
@@ -52,33 +68,38 @@ export const createTransactionServer = withErrorHandling(async (transactionData:
     };
   }
 
-  // Determine the effective tax status (local vs global)
-  let effectiveTaxStatus: "filer" | "non-filer" = "filer";
-  if (portfolio && !portfolio.useGlobalTax) {
-    effectiveTaxStatus = portfolio.taxStatus;
-  } else {
-    effectiveTaxStatus = settings.taxStatus;
-  }
+  // Determine the effective tax status (portfolio-local vs global)
+  const effectiveTaxStatus: "filer" | "non-filer" =
+    portfolio && !portfolio.useGlobalTax ? portfolio.taxStatus : settings.taxStatus;
 
-  if (transactionData.type === "dividend") {
-    if (
-      transactionData.commissionAndTaxes === undefined ||
-      transactionData.commissionAndTaxes === null ||
-      transactionData.commissionAndTaxes === 0
-    ) {
-      transactionData.commissionAndTaxes = effectiveTaxStatus === "filer" ? 15 : 30;
-      transactionData.isCommissionPercentage = true;
-    }
-  } else if (transactionData.type === "buy" || transactionData.type === "sell") {
-    if (
-      transactionData.commissionAndTaxes === undefined ||
-      transactionData.commissionAndTaxes === null ||
-      transactionData.commissionAndTaxes === 0
-    ) {
-      transactionData.commissionAndTaxes = settings.commissionRate;
-      transactionData.isCommissionPercentage = settings.isCommissionPercentage;
+  for (const item of items) {
+    if (item.type === "dividend") {
+      if (
+        item.commissionAndTaxes === undefined ||
+        item.commissionAndTaxes === null ||
+        item.commissionAndTaxes === 0
+      ) {
+        item.commissionAndTaxes = effectiveTaxStatus === "filer" ? 15 : 30;
+        item.isCommissionPercentage = true;
+      }
+    } else if (item.type === "buy" || item.type === "sell") {
+      if (
+        item.commissionAndTaxes === undefined ||
+        item.commissionAndTaxes === null ||
+        item.commissionAndTaxes === 0
+      ) {
+        item.commissionAndTaxes = settings.commissionRate;
+        item.isCommissionPercentage = settings.isCommissionPercentage;
+      }
     }
   }
+}
+
+export const createTransactionServer = withErrorHandling(async (transactionData: TransactionSchemaType) => {
+  const userId = await requireAuth();
+  await withPortfolioOwnership(transactionData.portfolioId, userId);
+
+  await applySettingsDefaults(userId, transactionData.portfolioId, [transactionData]);
 
   const formattedData = {
     ...transactionData,
@@ -116,62 +137,7 @@ export const createMultipleTransactions = withErrorHandling(async (transactions:
   const portfolioId = transactions[0].portfolioId;
   await withPortfolioOwnership(portfolioId, userId);
 
-  // Fetch portfolio settings scoped to user for security
-  const portfolio = await db
-    .select()
-    .from(portfolioTable)
-    .where(and(eq(portfolioTable.id, portfolioId), eq(portfolioTable.userId, userId)))
-    .limit(1)
-    .then((rows) => rows[0]);
-
-  // Query settings once and use local defaults if not found
-  let settings = await db
-    .select()
-    .from(userSettingsTable)
-    .where(eq(userSettingsTable.userId, userId))
-    .limit(1)
-    .then((rows) => rows[0]);
-
-  if (!settings) {
-    settings = {
-      userId,
-      taxStatus: "filer" as const,
-      commissionRate: 0.15,
-      isCommissionPercentage: true,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-  }
-
-  // Determine the effective tax status (local vs global)
-  let effectiveTaxStatus: "filer" | "non-filer" = "filer";
-  if (portfolio && !portfolio.useGlobalTax) {
-    effectiveTaxStatus = portfolio.taxStatus;
-  } else {
-    effectiveTaxStatus = settings.taxStatus;
-  }
-
-  transactions.forEach((transactionData) => {
-    if (transactionData.type === "dividend") {
-      if (
-        transactionData.commissionAndTaxes === undefined ||
-        transactionData.commissionAndTaxes === null ||
-        transactionData.commissionAndTaxes === 0
-      ) {
-        transactionData.commissionAndTaxes = effectiveTaxStatus === "filer" ? 15 : 30;
-        transactionData.isCommissionPercentage = true;
-      }
-    } else if (transactionData.type === "buy" || transactionData.type === "sell") {
-      if (
-        transactionData.commissionAndTaxes === undefined ||
-        transactionData.commissionAndTaxes === null ||
-        transactionData.commissionAndTaxes === 0
-      ) {
-        transactionData.commissionAndTaxes = settings.commissionRate;
-        transactionData.isCommissionPercentage = settings.isCommissionPercentage;
-      }
-    }
-  });
+  await applySettingsDefaults(userId, portfolioId, transactions);
 
   const sortedTransactions = sortTransactionsByDateAndType(transactions);
   await db.transaction(async (tx) => {

--- a/src/actions/transaction/TransactionFunctions.ts
+++ b/src/actions/transaction/TransactionFunctions.ts
@@ -6,7 +6,7 @@ import {
 } from "@/actions/portfolioPerformance/portfolioPerformance";
 import { getPostHogServer } from "@/app/posthog-server";
 import { db } from "@/db";
-import { transactionTable } from "@/db/schema";
+import { portfolioTable, transactionTable, userSettingsTable } from "@/db/schema";
 import { createTracedModel } from "@/lib/ai/aiClient";
 import { parseTransactionsAIResponse } from "@/lib/ai/helpers";
 import { TRANSACTION_PARSER_SYSTEM_PROMPT } from "@/lib/ai/prompts";
@@ -24,6 +24,60 @@ import { sortTransactionsByDateAndType } from "./helpers";
 export const createTransactionServer = withErrorHandling(async (transactionData: TransactionSchemaType) => {
   const userId = await requireAuth();
   await withPortfolioOwnership(transactionData.portfolioId, userId);
+
+  // Fetch portfolio settings
+  const portfolio = await db
+    .select()
+    .from(portfolioTable)
+    .where(eq(portfolioTable.id, transactionData.portfolioId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  // Determine the effective tax status (local vs global)
+  let effectiveTaxStatus: "filer" | "non-filer" = "filer";
+  if (portfolio && !portfolio.useGlobalTax) {
+    effectiveTaxStatus = portfolio.taxStatus;
+  } else {
+    const settings = await db
+      .select()
+      .from(userSettingsTable)
+      .where(eq(userSettingsTable.userId, userId))
+      .limit(1)
+      .then((rows) => rows[0]);
+    if (settings) {
+      effectiveTaxStatus = settings.taxStatus;
+    }
+  }
+
+  // Cross-reference user settings for commission rules
+  const settings = await db
+    .select()
+    .from(userSettingsTable)
+    .where(eq(userSettingsTable.userId, userId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (transactionData.type === "dividend") {
+    if (
+      transactionData.commissionAndTaxes === undefined ||
+      transactionData.commissionAndTaxes === null ||
+      transactionData.commissionAndTaxes === 0
+    ) {
+      transactionData.commissionAndTaxes = effectiveTaxStatus === "filer" ? 15 : 30;
+      transactionData.isCommissionPercentage = true;
+    }
+  } else if (transactionData.type === "buy" || transactionData.type === "sell") {
+    if (
+      transactionData.commissionAndTaxes === undefined ||
+      transactionData.commissionAndTaxes === null ||
+      transactionData.commissionAndTaxes === 0
+    ) {
+      if (settings) {
+        transactionData.commissionAndTaxes = settings.commissionRate;
+        transactionData.isCommissionPercentage = settings.isCommissionPercentage;
+      }
+    }
+  }
 
   const formattedData = {
     ...transactionData,
@@ -53,6 +107,62 @@ export const createMultipleTransactions = withErrorHandling(async (transactions:
   if (!transactions || transactions.length === 0) {
     throw new Error("No transactions provided");
   }
+
+  // Fetch portfolio settings
+  const portfolio = await db
+    .select()
+    .from(portfolioTable)
+    .where(eq(portfolioTable.id, transactions[0].portfolioId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  // Determine the effective tax status (local vs global)
+  let effectiveTaxStatus: "filer" | "non-filer" = "filer";
+  if (portfolio && !portfolio.useGlobalTax) {
+    effectiveTaxStatus = portfolio.taxStatus;
+  } else {
+    const settings = await db
+      .select()
+      .from(userSettingsTable)
+      .where(eq(userSettingsTable.userId, userId))
+      .limit(1)
+      .then((rows) => rows[0]);
+    if (settings) {
+      effectiveTaxStatus = settings.taxStatus;
+    }
+  }
+
+  // Cross-reference user settings for commission rules
+  const settings = await db
+    .select()
+    .from(userSettingsTable)
+    .where(eq(userSettingsTable.userId, userId))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  transactions.forEach((transactionData) => {
+    if (transactionData.type === "dividend") {
+      if (
+        transactionData.commissionAndTaxes === undefined ||
+        transactionData.commissionAndTaxes === null ||
+        transactionData.commissionAndTaxes === 0
+      ) {
+        transactionData.commissionAndTaxes = effectiveTaxStatus === "filer" ? 15 : 30;
+        transactionData.isCommissionPercentage = true;
+      }
+    } else if (transactionData.type === "buy" || transactionData.type === "sell") {
+      if (
+        transactionData.commissionAndTaxes === undefined ||
+        transactionData.commissionAndTaxes === null ||
+        transactionData.commissionAndTaxes === 0
+      ) {
+        if (settings) {
+          transactionData.commissionAndTaxes = settings.commissionRate;
+          transactionData.isCommissionPercentage = settings.isCommissionPercentage;
+        }
+      }
+    }
+  });
 
   const portfolioId = transactions[0].portfolioId;
   const sortedTransactions = sortTransactionsByDateAndType(transactions);

--- a/src/actions/userSettings/userSettingsActions.ts
+++ b/src/actions/userSettings/userSettingsActions.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { db } from "@/db";
+import { userSettingsTable, UserSettings } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { updateTag, unstable_cache } from "next/cache";
+import { requireAuth, withErrorHandling } from "../utils/middleware";
+
+export const getUserSettings = withErrorHandling(async () => {
+  const userId = await requireAuth();
+
+  const getCachedSettings = unstable_cache(
+    async (id: string) => {
+      let settings = await db
+        .select()
+        .from(userSettingsTable)
+        .where(eq(userSettingsTable.userId, id))
+        .limit(1)
+        .then((rows) => rows[0]);
+
+      if (!settings) {
+        // Create default settings if not exists
+        const defaultSettings = {
+          userId: id,
+          taxStatus: "filer" as const,
+          commissionRate: 0.15,
+          isCommissionPercentage: true,
+        };
+        const result = await db.insert(userSettingsTable).values(defaultSettings).returning();
+        settings = result[0];
+      }
+      return settings;
+    },
+    [`user-settings-${userId}`],
+    {
+      tags: [`user-settings-${userId}`],
+      revalidate: 60 * 60, // Cache for 1 hour
+    }
+  );
+
+  return await getCachedSettings(userId);
+});
+
+export const updateUserSettings = withErrorHandling(
+  async (data: Omit<UserSettings, "userId" | "createdAt" | "updatedAt">) => {
+    const userId = await requireAuth();
+
+    // Upsert user settings
+    const existing = await db
+      .select()
+      .from(userSettingsTable)
+      .where(eq(userSettingsTable.userId, userId))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    let updated;
+    if (existing) {
+      const result = await db
+        .update(userSettingsTable)
+        .set({
+          taxStatus: data.taxStatus,
+          commissionRate: data.commissionRate,
+          isCommissionPercentage: data.isCommissionPercentage,
+          updatedAt: new Date(),
+        })
+        .where(eq(userSettingsTable.userId, userId))
+        .returning();
+      updated = result[0];
+    } else {
+      const result = await db
+        .insert(userSettingsTable)
+        .values({
+          userId,
+          taxStatus: data.taxStatus,
+          commissionRate: data.commissionRate,
+          isCommissionPercentage: data.isCommissionPercentage,
+        })
+        .returning();
+      updated = result[0];
+    }
+
+    updateTag(`user-settings-${userId}`);
+    return updated;
+  }
+);

--- a/src/actions/userSettings/userSettingsActions.ts
+++ b/src/actions/userSettings/userSettingsActions.ts
@@ -19,15 +19,30 @@ export const getUserSettings = withErrorHandling(async () => {
         .then((rows) => rows[0]);
 
       if (!settings) {
-        // Create default settings if not exists
+        // Create default settings atomically if not exists
         const defaultSettings = {
           userId: id,
           taxStatus: "filer" as const,
           commissionRate: 0.15,
           isCommissionPercentage: true,
         };
-        const result = await db.insert(userSettingsTable).values(defaultSettings).returning();
-        settings = result[0];
+        const result = await db
+          .insert(userSettingsTable)
+          .values(defaultSettings)
+          .onConflictDoNothing()
+          .returning();
+        
+        if (result.length > 0) {
+          settings = result[0];
+        } else {
+          // If conflict occurred, select the setting created by concurrent query
+          settings = await db
+            .select()
+            .from(userSettingsTable)
+            .where(eq(userSettingsTable.userId, id))
+            .limit(1)
+            .then((rows) => rows[0]);
+        }
       }
       return settings;
     },
@@ -45,40 +60,39 @@ export const updateUserSettings = withErrorHandling(
   async (data: Omit<UserSettings, "userId" | "createdAt" | "updatedAt">) => {
     const userId = await requireAuth();
 
-    // Upsert user settings
-    const existing = await db
-      .select()
-      .from(userSettingsTable)
-      .where(eq(userSettingsTable.userId, userId))
-      .limit(1)
-      .then((rows) => rows[0]);
+    if (data.taxStatus !== "filer" && data.taxStatus !== "non-filer") {
+      throw new Error("Invalid tax status value");
+    }
+    if (typeof data.commissionRate !== "number" || !isFinite(data.commissionRate) || data.commissionRate < 0) {
+      throw new Error("Commission rate must be a non-negative finite number");
+    }
+    if (data.isCommissionPercentage && data.commissionRate > 100) {
+      throw new Error("Commission rate percentage cannot exceed 100%");
+    }
+    if (typeof data.isCommissionPercentage !== "boolean") {
+      throw new Error("isCommissionPercentage must be a boolean");
+    }
 
-    let updated;
-    if (existing) {
-      const result = await db
-        .update(userSettingsTable)
-        .set({
+    const result = await db
+      .insert(userSettingsTable)
+      .values({
+        userId,
+        taxStatus: data.taxStatus,
+        commissionRate: data.commissionRate,
+        isCommissionPercentage: data.isCommissionPercentage,
+      })
+      .onConflictDoUpdate({
+        target: userSettingsTable.userId,
+        set: {
           taxStatus: data.taxStatus,
           commissionRate: data.commissionRate,
           isCommissionPercentage: data.isCommissionPercentage,
           updatedAt: new Date(),
-        })
-        .where(eq(userSettingsTable.userId, userId))
-        .returning();
-      updated = result[0];
-    } else {
-      const result = await db
-        .insert(userSettingsTable)
-        .values({
-          userId,
-          taxStatus: data.taxStatus,
-          commissionRate: data.commissionRate,
-          isCommissionPercentage: data.isCommissionPercentage,
-        })
-        .returning();
-      updated = result[0];
-    }
+        },
+      })
+      .returning();
 
+    const updated = result[0];
     updateTag(`user-settings-${userId}`);
     return updated;
   }

--- a/src/actions/userSettings/userSettingsActions.ts
+++ b/src/actions/userSettings/userSettingsActions.ts
@@ -1,8 +1,8 @@
 "use server";
 
 import { db } from "@/db";
-import { userSettingsTable, UserSettings } from "@/db/schema";
-import { eq } from "drizzle-orm";
+import { userSettingsTable, UserSettings, portfolioTable } from "@/db/schema";
+import { and, eq } from "drizzle-orm";
 import { updateTag, unstable_cache } from "next/cache";
 import { requireAuth, withErrorHandling } from "../utils/middleware";
 
@@ -73,27 +73,37 @@ export const updateUserSettings = withErrorHandling(
       throw new Error("isCommissionPercentage must be a boolean");
     }
 
-    const result = await db
-      .insert(userSettingsTable)
-      .values({
-        userId,
-        taxStatus: data.taxStatus,
-        commissionRate: data.commissionRate,
-        isCommissionPercentage: data.isCommissionPercentage,
-      })
-      .onConflictDoUpdate({
-        target: userSettingsTable.userId,
-        set: {
+    const result = await db.transaction(async (tx) => {
+      const txResult = await tx
+        .insert(userSettingsTable)
+        .values({
+          userId,
           taxStatus: data.taxStatus,
           commissionRate: data.commissionRate,
           isCommissionPercentage: data.isCommissionPercentage,
-          updatedAt: new Date(),
-        },
-      })
-      .returning();
+        })
+        .onConflictDoUpdate({
+          target: userSettingsTable.userId,
+          set: {
+            taxStatus: data.taxStatus,
+            commissionRate: data.commissionRate,
+            isCommissionPercentage: data.isCommissionPercentage,
+            updatedAt: new Date(),
+          },
+        })
+        .returning();
+
+      await tx
+        .update(portfolioTable)
+        .set({ taxStatus: data.taxStatus })
+        .where(and(eq(portfolioTable.userId, userId), eq(portfolioTable.useGlobalTax, true)));
+
+      return txResult;
+    });
 
     const updated = result[0];
     updateTag(`user-settings-${userId}`);
+    updateTag(`user-${userId}-portfolios`);
     return updated;
   }
 );

--- a/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/formSchema.ts
+++ b/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/formSchema.ts
@@ -10,6 +10,8 @@ export const createPortfolioSchema = z.object({
   backgroundColor: z.string().trim().min(1, {
     message: "Background color is required.",
   }),
+  useGlobalTax: z.boolean().default(true),
+  taxStatus: z.enum(["filer", "non-filer"]).default("filer"),
 });
 
 export const updatePortfolioSchema = createPortfolioSchema.extend({

--- a/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/index.tsx
@@ -108,7 +108,7 @@ export const CreatePortfolioForm = ({ onSuccess, portfolio }: CreatePortfolioFor
       updatePortfolioMutation.mutate({ ...portfolio, ...data, id: portfolio.id }, { onSuccess });
     } else {
       const { title, emoji, backgroundColor, useGlobalTax, taxStatus } = data;
-      createPortfolioMutation.mutate({ title, emoji, backgroundColor, useGlobalTax, taxStatus } as any, { onSuccess });
+      createPortfolioMutation.mutate({ title, emoji, backgroundColor, useGlobalTax, taxStatus }, { onSuccess });
     }
   };
 

--- a/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/CreatePortfolioForm/index.tsx
@@ -11,6 +11,7 @@ import { motion } from "motion/react";
 import React from "react";
 import { useForm } from "react-hook-form";
 import { createPortfolioSchema, updatePortfolioSchema } from "./formSchema";
+import { Switch } from "@/components/ui/switch";
 
 const portfolioEmojis = [
   "🚀",
@@ -70,6 +71,8 @@ export const CreatePortfolioForm = ({ onSuccess, portfolio }: CreatePortfolioFor
     title: string;
     emoji: string;
     backgroundColor: string;
+    useGlobalTax: boolean;
+    taxStatus: "filer" | "non-filer";
     id?: number;
   };
 
@@ -88,6 +91,8 @@ export const CreatePortfolioForm = ({ onSuccess, portfolio }: CreatePortfolioFor
       title: portfolio?.title || "",
       emoji: portfolio?.emoji || portfolioEmojis[0],
       backgroundColor: portfolio?.backgroundColor || portfolioColors[0].hex,
+      useGlobalTax: portfolio?.useGlobalTax ?? true,
+      taxStatus: portfolio?.taxStatus ?? "filer",
       id: portfolio?.id,
     },
   });
@@ -95,13 +100,15 @@ export const CreatePortfolioForm = ({ onSuccess, portfolio }: CreatePortfolioFor
   /* eslint-disable-next-line react-hooks/incompatible-library -- React Hook Form's watch() cannot be memoized safely; React Compiler skips this component */
   const selectedEmoji = watch("emoji");
   const selectedColorHex = watch("backgroundColor");
+  const useGlobalTax = watch("useGlobalTax");
+  const taxStatus = watch("taxStatus");
 
   const onSubmit = (data: PortfolioFormValues) => {
     if (portfolio) {
       updatePortfolioMutation.mutate({ ...portfolio, ...data, id: portfolio.id }, { onSuccess });
     } else {
-      const { title, emoji, backgroundColor } = data;
-      createPortfolioMutation.mutate({ title, emoji, backgroundColor } as any, { onSuccess });
+      const { title, emoji, backgroundColor, useGlobalTax, taxStatus } = data;
+      createPortfolioMutation.mutate({ title, emoji, backgroundColor, useGlobalTax, taxStatus } as any, { onSuccess });
     }
   };
 
@@ -207,6 +214,63 @@ export const CreatePortfolioForm = ({ onSuccess, portfolio }: CreatePortfolioFor
             ))}
           </div>
         </div>
+      </motion.div>
+
+      {/* Tax Settings */}
+      <motion.div
+        initial={{ y: 20, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ delay: 0.55, duration: 0.5 }}
+        className="space-y-4 rounded-lg border border-white/10 bg-blue-900/20 p-4 backdrop-blur-sm"
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-1">
+            <Label className="text-sm font-semibold text-slate-200 block">
+              Use Global Tax Settings
+            </Label>
+            <p className="text-xs text-slate-400">
+              When enabled, this portfolio will use your account&apos;s global tax settings.
+            </p>
+          </div>
+          <Switch
+            id="portfolio-use-global-tax"
+            checked={useGlobalTax}
+            onCheckedChange={(checked) => setValue("useGlobalTax", checked, { shouldValidate: true })}
+            className="data-[state=checked]:bg-blue-600"
+          />
+        </div>
+
+        {!useGlobalTax && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="pt-2 border-t border-white/5 space-y-4"
+          >
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 rounded-lg bg-slate-950/40 p-3 border border-slate-800/40">
+              <div className="space-y-1">
+                <Label className="text-sm font-semibold text-slate-200">
+                  Local Tax Status: <span className="text-blue-400 uppercase font-bold">{taxStatus}</span>
+                </Label>
+                <p className="text-xs text-slate-400">
+                  {taxStatus === "filer"
+                    ? "Local filer status applies a 15% withholding tax rate on dividends."
+                    : "Local non-filer status applies a 30% withholding tax rate on dividends."}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-slate-400 font-medium">Non-Filer</span>
+                <Switch
+                  id="portfolio-local-tax-status"
+                  checked={taxStatus === "filer"}
+                  onCheckedChange={(checked) => setValue("taxStatus", checked ? "filer" : "non-filer", { shouldValidate: true })}
+                  className="data-[state=checked]:bg-blue-600"
+                />
+                <span className="text-xs text-blue-400 font-semibold">Filer</span>
+              </div>
+            </div>
+          </motion.div>
+        )}
       </motion.div>
 
       <motion.div

--- a/src/app/portfolio/[portfolioId]/components/PortfoliosSidebar/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/PortfoliosSidebar/index.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/animate-ui/components/radix/sidebar";
 import { Button } from "@/components/ui/button";
 import { Portfolio } from "@/db/schema";
-import { HelpCircle, Loader2, Mail, Plus } from "lucide-react";
+import { HelpCircle, Loader2, Mail, Plus, Settings } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -134,9 +134,25 @@ export const PortfoliosSidebar = ({ portfolioList, children }: PortfoliosSidebar
           </SidebarGroup>
         </SidebarContent>
 
-        {/* Footer with Install Button and User Account */}
-        <SidebarFooter className="shrink-0 border-t border-sidebar-border/70 bg-sidebar-accent/10 px-3 py-4">
+        {/* Footer with Install Button, Settings and User Account */}
+        <SidebarFooter className="shrink-0 border-t border-sidebar-border/70 bg-sidebar-accent/10 px-3 py-4 gap-2">
           <SidebarInstallButton />
+          
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname === "/settings"}
+                className="rounded-md border border-transparent hover:bg-sidebar-accent data-[active=true]:border-primary/60 data-[active=true]:bg-sidebar-accent/80"
+              >
+                <Link href="/settings">
+                  <Settings className="h-4 w-4" />
+                  <span>Settings</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+
           <SidebarUserSection />
         </SidebarFooter>
       </Sidebar>

--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
@@ -17,7 +17,7 @@ import { useUserSettings } from "@/utils/hooks/useUserSettings";
 import { usePortfolio } from "@/utils/hooks/usePortfolio";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { StockSelect } from "../components/StockSelect";
 import {
   DateInput,
@@ -76,10 +76,14 @@ export default function TransactionForm(props: TransactionFormProps) {
   const transactionType = form.watch("type");
   const isDividend = transactionType === "dividend";
   const { dirtyFields } = form.formState;
+  const prevTransactionType = useRef(transactionType);
 
   // Automatically pre-fill default values from settings when transaction type changes
   useEffect(() => {
     if (editTransactionId) return; // Do not overwrite values during edit flow
+
+    const isTabSwitch = prevTransactionType.current !== transactionType;
+    prevTransactionType.current = transactionType;
 
     const portfolio = portfolios?.find((p) => p.id === portfolioId);
     let effectiveTaxStatus: "filer" | "non-filer" = "filer";
@@ -90,17 +94,17 @@ export default function TransactionForm(props: TransactionFormProps) {
     }
 
     if (transactionType === "dividend") {
-      if (!dirtyFields.commissionAndTaxes) {
+      if (!dirtyFields.commissionAndTaxes || isTabSwitch) {
         form.setValue("commissionAndTaxes", effectiveTaxStatus === "filer" ? 15 : 30);
       }
-      if (!dirtyFields.isCommissionPercentage) {
+      if (!dirtyFields.isCommissionPercentage || isTabSwitch) {
         form.setValue("isCommissionPercentage", true);
       }
     } else if (transactionType === "buy" || transactionType === "sell") {
-      if (!dirtyFields.commissionAndTaxes) {
+      if (!dirtyFields.commissionAndTaxes || isTabSwitch) {
         form.setValue("commissionAndTaxes", settings ? settings.commissionRate : 0.15);
       }
-      if (!dirtyFields.isCommissionPercentage) {
+      if (!dirtyFields.isCommissionPercentage || isTabSwitch) {
         form.setValue("isCommissionPercentage", settings ? settings.isCommissionPercentage : true);
       }
     }

--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
@@ -75,6 +75,7 @@ export default function TransactionForm(props: TransactionFormProps) {
 
   const transactionType = form.watch("type");
   const isDividend = transactionType === "dividend";
+  const { dirtyFields } = form.formState;
 
   // Automatically pre-fill default values from settings when transaction type changes
   useEffect(() => {
@@ -89,18 +90,30 @@ export default function TransactionForm(props: TransactionFormProps) {
     }
 
     if (transactionType === "dividend") {
-      form.setValue("commissionAndTaxes", effectiveTaxStatus === "filer" ? 15 : 30);
-      form.setValue("isCommissionPercentage", true);
-    } else if (transactionType === "buy" || transactionType === "sell") {
-      if (settings) {
-        form.setValue("commissionAndTaxes", settings.commissionRate);
-        form.setValue("isCommissionPercentage", settings.isCommissionPercentage);
-      } else {
-        form.setValue("commissionAndTaxes", 0.15);
+      if (!dirtyFields.commissionAndTaxes) {
+        form.setValue("commissionAndTaxes", effectiveTaxStatus === "filer" ? 15 : 30);
+      }
+      if (!dirtyFields.isCommissionPercentage) {
         form.setValue("isCommissionPercentage", true);
       }
+    } else if (transactionType === "buy" || transactionType === "sell") {
+      if (!dirtyFields.commissionAndTaxes) {
+        form.setValue("commissionAndTaxes", settings ? settings.commissionRate : 0.15);
+      }
+      if (!dirtyFields.isCommissionPercentage) {
+        form.setValue("isCommissionPercentage", settings ? settings.isCommissionPercentage : true);
+      }
     }
-  }, [transactionType, settings, portfolios, portfolioId, editTransactionId, form]);
+  }, [
+    transactionType,
+    settings,
+    portfolios,
+    portfolioId,
+    editTransactionId,
+    form,
+    dirtyFields.commissionAndTaxes,
+    dirtyFields.isCommissionPercentage,
+  ]);
 
   const onSubmit = async (
     data: BuyTransactionSchemaType | SellTransactionSchemaType | DividendTransactionSchemaType

--- a/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
+++ b/src/app/portfolio/[portfolioId]/components/TransactionForm/TransactionForm/index.tsx
@@ -13,8 +13,11 @@ import {
   SellTransaction,
 } from "@/types";
 import { useTransactions } from "@/utils/hooks/useTransactionData";
+import { useUserSettings } from "@/utils/hooks/useUserSettings";
+import { usePortfolio } from "@/utils/hooks/usePortfolio";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
+import { useEffect } from "react";
 import { StockSelect } from "../components/StockSelect";
 import {
   DateInput,
@@ -41,6 +44,8 @@ export default function TransactionForm(props: TransactionFormProps) {
   const { onSuccess, portfolioId, editTransaction, editTransactionId } = props;
 
   const { createTransaction, updateTransaction } = useTransactions(portfolioId);
+  const { settings } = useUserSettings();
+  const { portfolios } = usePortfolio();
 
   // Get the appropriate schema and type based on transaction type
   const editTransactionType = editTransaction?.type || "buy";
@@ -70,6 +75,32 @@ export default function TransactionForm(props: TransactionFormProps) {
 
   const transactionType = form.watch("type");
   const isDividend = transactionType === "dividend";
+
+  // Automatically pre-fill default values from settings when transaction type changes
+  useEffect(() => {
+    if (editTransactionId) return; // Do not overwrite values during edit flow
+
+    const portfolio = portfolios?.find((p) => p.id === portfolioId);
+    let effectiveTaxStatus: "filer" | "non-filer" = "filer";
+    if (portfolio && !portfolio.useGlobalTax) {
+      effectiveTaxStatus = portfolio.taxStatus;
+    } else if (settings) {
+      effectiveTaxStatus = settings.taxStatus;
+    }
+
+    if (transactionType === "dividend") {
+      form.setValue("commissionAndTaxes", effectiveTaxStatus === "filer" ? 15 : 30);
+      form.setValue("isCommissionPercentage", true);
+    } else if (transactionType === "buy" || transactionType === "sell") {
+      if (settings) {
+        form.setValue("commissionAndTaxes", settings.commissionRate);
+        form.setValue("isCommissionPercentage", settings.isCommissionPercentage);
+      } else {
+        form.setValue("commissionAndTaxes", 0.15);
+        form.setValue("isCommissionPercentage", true);
+      }
+    }
+  }, [transactionType, settings, portfolios, portfolioId, editTransactionId, form]);
 
   const onSubmit = async (
     data: BuyTransactionSchemaType | SellTransactionSchemaType | DividendTransactionSchemaType

--- a/src/app/settings/components/UserSettingsForm.tsx
+++ b/src/app/settings/components/UserSettingsForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { toast } from "@/components/molecules/Toast";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -12,44 +11,38 @@ import { SidebarTrigger } from "@/components/animate-ui/components/radix/sidebar
 import { updateUserSettings } from "@/actions/userSettings/userSettingsActions";
 import { UserSettings } from "@/db/schema";
 import { Shield, Percent, Save, Loader2, Info } from "lucide-react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { userSettingsSchema, UserSettingsFormValues } from "./formSchema";
 
 interface UserSettingsFormProps {
   initialSettings: UserSettings | null;
 }
 
-export default function UserSettingsForm({ initialSettings }: UserSettingsFormProps) {
-  const [taxStatus, setTaxStatus] = useState<"filer" | "non-filer">(initialSettings?.taxStatus ?? "filer");
-  const [commissionRate, setCommissionRate] = useState<number>(initialSettings?.commissionRate ?? 0.15);
-  const [isCommissionPercentage, setIsCommissionPercentage] = useState<boolean>(
-    initialSettings?.isCommissionPercentage ?? true
-  );
-  const [isSaving, setIsSaving] = useState(false);
+const DEFAULT_COMMISSION_RATE = 0.15;
 
-  const handleSave = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (commissionRate < 0) {
-      toast({
-        type: "error",
-        title: "Invalid Commission Rate",
-        description: "Commission rate cannot be negative.",
-      });
-      return;
-    }
-    if (isCommissionPercentage && commissionRate > 100) {
-      toast({
-        type: "error",
-        title: "Invalid Commission Rate",
-        description: "Percentage commission rate cannot exceed 100%.",
-      });
-      return;
-    }
-    setIsSaving(true);
+export default function UserSettingsForm({ initialSettings }: UserSettingsFormProps) {
+  const {
+    register,
+    handleSubmit,
+    control,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<UserSettingsFormValues>({
+    resolver: zodResolver(userSettingsSchema),
+    defaultValues: {
+      taxStatus: initialSettings?.taxStatus ?? "filer",
+      commissionRate: initialSettings?.commissionRate ?? DEFAULT_COMMISSION_RATE,
+      isCommissionPercentage: initialSettings?.isCommissionPercentage ?? true,
+    },
+  });
+
+  const taxStatus = watch("taxStatus");
+  const isCommissionPercentage = watch("isCommissionPercentage");
+
+  const onSubmit = async (values: UserSettingsFormValues) => {
     try {
-      const response = await updateUserSettings({
-        taxStatus,
-        commissionRate: Number(commissionRate) || 0,
-        isCommissionPercentage,
-      });
+      const response = await updateUserSettings(values);
 
       if (response.success) {
         toast({
@@ -68,8 +61,6 @@ export default function UserSettingsForm({ initialSettings }: UserSettingsFormPr
         type: "error",
         title: "An unexpected error occurred while saving settings.",
       });
-    } finally {
-      setIsSaving(false);
     }
   };
 
@@ -96,7 +87,7 @@ export default function UserSettingsForm({ initialSettings }: UserSettingsFormPr
             </p>
           </div>
 
-          <form onSubmit={handleSave} className="space-y-6">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
             {/* Tax Profile Card */}
             <Card className="border-slate-800 bg-slate-900/40 shadow-md backdrop-blur-sm">
               <div className="flex flex-col space-y-1.5 p-6 pb-3">
@@ -122,11 +113,17 @@ export default function UserSettingsForm({ initialSettings }: UserSettingsFormPr
                   </div>
                   <div className="flex items-center gap-2">
                     <span className="text-xs text-slate-400 font-medium">Non-Filer</span>
-                    <Switch
-                      id="tax-status-toggle"
-                      checked={taxStatus === "filer"}
-                      onCheckedChange={(checked) => setTaxStatus(checked ? "filer" : "non-filer")}
-                      className="data-[state=checked]:bg-primary"
+                    <Controller
+                      name="taxStatus"
+                      control={control}
+                      render={({ field }) => (
+                        <Switch
+                          id="tax-status-toggle"
+                          checked={field.value === "filer"}
+                          onCheckedChange={(checked) => field.onChange(checked ? "filer" : "non-filer")}
+                          className="data-[state=checked]:bg-primary"
+                        />
+                      )}
                     />
                     <span className="text-xs text-slate-200 font-semibold">Filer</span>
                   </div>
@@ -165,36 +162,41 @@ export default function UserSettingsForm({ initialSettings }: UserSettingsFormPr
                         step="any"
                         min="0"
                         max={isCommissionPercentage ? "100" : undefined}
-                        placeholder="0.15"
-                        value={commissionRate}
-                        onChange={(e) => {
-                          const val = parseFloat(e.target.value);
-                          setCommissionRate(isNaN(val) ? 0 : val);
-                        }}
+                        placeholder={String(DEFAULT_COMMISSION_RATE)}
+                        {...register("commissionRate")}
                         className="bg-slate-950/50 border-slate-800 text-slate-100 pr-8 focus:ring-primary focus:border-primary"
                       />
                       <div className="absolute right-3 top-2.5 text-xs text-slate-500">
                         {isCommissionPercentage ? "%" : "PKR"}
                       </div>
                     </div>
+                    {errors.commissionRate && (
+                      <p className="text-xs text-red-400">{errors.commissionRate.message}</p>
+                    )}
                   </div>
 
                   <div className="space-y-2">
                     <Label htmlFor="commission-type" className="text-sm font-semibold text-slate-200">
                       Commission Type
                     </Label>
-                    <Select
-                      value={isCommissionPercentage ? "percentage" : "flat"}
-                      onValueChange={(val) => setIsCommissionPercentage(val === "percentage")}
-                    >
-                      <SelectTrigger id="commission-type" className="bg-slate-950/50 border-slate-800 text-slate-100">
-                        <SelectValue placeholder="Select type" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-900 border-slate-800 text-slate-100">
-                        <SelectItem value="percentage">Percentage (%)</SelectItem>
-                        <SelectItem value="flat">Flat Fee (PKR)</SelectItem>
-                      </SelectContent>
-                    </Select>
+                    <Controller
+                      name="isCommissionPercentage"
+                      control={control}
+                      render={({ field }) => (
+                        <Select
+                          value={field.value ? "percentage" : "flat"}
+                          onValueChange={(val) => field.onChange(val === "percentage")}
+                        >
+                          <SelectTrigger id="commission-type" className="bg-slate-950/50 border-slate-800 text-slate-100">
+                            <SelectValue placeholder="Select type" />
+                          </SelectTrigger>
+                          <SelectContent className="bg-slate-900 border-slate-800 text-slate-100">
+                            <SelectItem value="percentage">Percentage (%)</SelectItem>
+                            <SelectItem value="flat">Flat Fee (PKR)</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      )}
+                    />
                   </div>
                 </div>
 
@@ -211,10 +213,10 @@ export default function UserSettingsForm({ initialSettings }: UserSettingsFormPr
             <div className="flex justify-end pt-2">
               <Button
                 type="submit"
-                disabled={isSaving}
+                disabled={isSubmitting}
                 className="bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-medium px-6 py-2 rounded-md shadow-md hover:shadow-lg transition-all duration-200 flex items-center gap-2"
               >
-                {isSaving ? (
+                {isSubmitting ? (
                   <>
                     <Loader2 className="h-4 w-4 animate-spin" />
                     Saving...

--- a/src/app/settings/components/UserSettingsForm.tsx
+++ b/src/app/settings/components/UserSettingsForm.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "@/components/molecules/Toast";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { SidebarTrigger } from "@/components/animate-ui/components/radix/sidebar";
+import { updateUserSettings } from "@/actions/userSettings/userSettingsActions";
+import { UserSettings } from "@/db/schema";
+import { Shield, Percent, Save, Loader2, Info } from "lucide-react";
+
+interface UserSettingsFormProps {
+  initialSettings: UserSettings | null;
+}
+
+export default function UserSettingsForm({ initialSettings }: UserSettingsFormProps) {
+  const [taxStatus, setTaxStatus] = useState<"filer" | "non-filer">(initialSettings?.taxStatus ?? "filer");
+  const [commissionRate, setCommissionRate] = useState<number>(initialSettings?.commissionRate ?? 0.15);
+  const [isCommissionPercentage, setIsCommissionPercentage] = useState<boolean>(
+    initialSettings?.isCommissionPercentage ?? true
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSaving(true);
+    try {
+      const response = await updateUserSettings({
+        taxStatus,
+        commissionRate: Number(commissionRate) || 0,
+        isCommissionPercentage,
+      });
+
+      if (response.success) {
+        toast({
+          type: "success",
+          title: "Settings updated successfully!",
+        });
+      } else {
+        toast({
+          type: "error",
+          title: "Failed to update settings",
+          description: response.message || undefined,
+        });
+      }
+    } catch {
+      toast({
+        type: "error",
+        title: "An unexpected error occurred while saving settings.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col rounded-none border border-sidebar-border/70 bg-sidebar/85 p-0 shadow-[0_10px_40px_rgba(0,0,0,0.25)] backdrop-blur-md">
+      {/* Header bar */}
+      <div className="flex shrink-0 flex-col items-stretch gap-2 border-b border-sidebar-border/80 bg-background/10 px-2 py-3 md:flex-row md:items-center md:justify-between md:px-4">
+        <div className="flex items-center gap-2">
+          <SidebarTrigger className="size-8 border border-primary/50 bg-sidebar-accent/60 text-sidebar-foreground shadow-sm hover:bg-sidebar-accent" />
+          <div className="h-6 w-px bg-sidebar-border/80" />
+          <h1 className="text-lg font-bold text-gray-100 tracking-tight md:text-xl">
+            User Settings
+          </h1>
+        </div>
+      </div>
+
+      {/* Form Content */}
+      <div className="no-scrollbar flex-1 overflow-y-auto px-4 py-6 md:px-8 bg-slate-950/20">
+        <div className="mx-auto max-w-2xl space-y-6">
+          <div>
+            <h2 className="text-2xl font-bold tracking-tight text-white">Financial Automation Profiles</h2>
+            <p className="text-sm text-slate-400 mt-1">
+              Configure your default tax bracket and broker fee rules. These settings will automatically compute and auto-fill transaction entries.
+            </p>
+          </div>
+
+          <form onSubmit={handleSave} className="space-y-6">
+            {/* Tax Profile Card */}
+            <Card className="border-slate-800 bg-slate-900/40 shadow-md backdrop-blur-sm">
+              <div className="flex flex-col space-y-1.5 p-6 pb-3">
+                <div className="flex items-center gap-2">
+                  <Shield className="h-5 w-5 text-slate-300" />
+                  <h3 className="text-lg font-semibold text-slate-100 leading-none tracking-tight">Tax Profile</h3>
+                </div>
+                <p className="text-sm text-slate-400">
+                  Configure your withholding tax status for automatically computing dividend tax rates.
+                </p>
+              </div>
+              <div className="p-6 pt-0 space-y-4">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 rounded-lg bg-slate-950/40 p-4 border border-slate-800/40">
+                  <div className="space-y-1">
+                    <Label htmlFor="tax-status-toggle" className="text-sm font-semibold text-slate-200">
+                      Tax Status: <span className="text-slate-100 uppercase font-bold">{taxStatus}</span>
+                    </Label>
+                    <p className="text-xs text-slate-400">
+                      {taxStatus === "filer"
+                        ? "Filer status applies a default 15% withholding tax rate on dividends."
+                        : "Non-Filer status applies a default 30% withholding tax rate on dividends."}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-slate-400 font-medium">Non-Filer</span>
+                    <Switch
+                      id="tax-status-toggle"
+                      checked={taxStatus === "filer"}
+                      onCheckedChange={(checked) => setTaxStatus(checked ? "filer" : "non-filer")}
+                      className="data-[state=checked]:bg-primary"
+                    />
+                    <span className="text-xs text-slate-200 font-semibold">Filer</span>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-2 bg-slate-950/40 border border-slate-800/60 rounded-md p-3 text-xs text-slate-400">
+                  <Info className="h-4 w-4 mt-0.5 shrink-0 text-slate-400" />
+                  <p>
+                    These rates match the standard Pakistan Stock Exchange (PSX) withholding tax regulations. Taxes on dividends will automatically be calculated as 15% (for filers) or 30% (for non-filers) of gross dividend payout when not explicitly entered.
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Brokerage Rules Card */}
+            <Card className="border-slate-800 bg-slate-900/40 shadow-md backdrop-blur-sm">
+              <div className="flex flex-col space-y-1.5 p-6 pb-3">
+                <div className="flex items-center gap-2">
+                  <Percent className="h-5 w-5 text-slate-300" />
+                  <h3 className="text-lg font-semibold text-slate-100 leading-none tracking-tight">Brokerage Commission Rules</h3>
+                </div>
+                <p className="text-sm text-slate-400">
+                  Set default commission rules applied to all your buy and sell transactions.
+                </p>
+              </div>
+              <div className="p-6 pt-0 space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="commission-rate" className="text-sm font-semibold text-slate-200">
+                      Default Commission Rate
+                    </Label>
+                    <div className="relative">
+                      <Input
+                        id="commission-rate"
+                        type="number"
+                        step="any"
+                        placeholder="0.15"
+                        value={commissionRate}
+                        onChange={(e) => setCommissionRate(parseFloat(e.target.value) || 0)}
+                        className="bg-slate-950/50 border-slate-800 text-slate-100 pr-8 focus:ring-primary focus:border-primary"
+                      />
+                      <div className="absolute right-3 top-2.5 text-xs text-slate-500">
+                        {isCommissionPercentage ? "%" : "PKR"}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="commission-type" className="text-sm font-semibold text-slate-200">
+                      Commission Type
+                    </Label>
+                    <Select
+                      value={isCommissionPercentage ? "percentage" : "flat"}
+                      onValueChange={(val) => setIsCommissionPercentage(val === "percentage")}
+                    >
+                      <SelectTrigger id="commission-type" className="bg-slate-950/50 border-slate-800 text-slate-100">
+                        <SelectValue placeholder="Select type" />
+                      </SelectTrigger>
+                      <SelectContent className="bg-slate-900 border-slate-800 text-slate-100">
+                        <SelectItem value="percentage">Percentage (%)</SelectItem>
+                        <SelectItem value="flat">Flat Fee (PKR)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-2 bg-slate-950/40 border border-slate-800/60 rounded-md p-3 text-xs text-slate-400">
+                  <Info className="h-4 w-4 mt-0.5 shrink-0 text-slate-400" />
+                  <p>
+                    For percentage commission, the fee is calculated as a percentage of the total transaction volume (Price × Shares). For flat fee, the absolute rate is added to buys and deducted from sells.
+                  </p>
+                </div>
+              </div>
+            </Card>
+
+            {/* Save Button */}
+            <div className="flex justify-end pt-2">
+              <Button
+                type="submit"
+                disabled={isSaving}
+                className="bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 text-white font-medium px-6 py-2 rounded-md shadow-md hover:shadow-lg transition-all duration-200 flex items-center gap-2"
+              >
+                {isSaving ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  <>
+                    <Save className="h-4 w-4" />
+                    Save Settings
+                  </>
+                )}
+              </Button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/settings/components/UserSettingsForm.tsx
+++ b/src/app/settings/components/UserSettingsForm.tsx
@@ -27,6 +27,22 @@ export default function UserSettingsForm({ initialSettings }: UserSettingsFormPr
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (commissionRate < 0) {
+      toast({
+        type: "error",
+        title: "Invalid Commission Rate",
+        description: "Commission rate cannot be negative.",
+      });
+      return;
+    }
+    if (isCommissionPercentage && commissionRate > 100) {
+      toast({
+        type: "error",
+        title: "Invalid Commission Rate",
+        description: "Percentage commission rate cannot exceed 100%.",
+      });
+      return;
+    }
     setIsSaving(true);
     try {
       const response = await updateUserSettings({
@@ -147,9 +163,14 @@ export default function UserSettingsForm({ initialSettings }: UserSettingsFormPr
                         id="commission-rate"
                         type="number"
                         step="any"
+                        min="0"
+                        max={isCommissionPercentage ? "100" : undefined}
                         placeholder="0.15"
                         value={commissionRate}
-                        onChange={(e) => setCommissionRate(parseFloat(e.target.value) || 0)}
+                        onChange={(e) => {
+                          const val = parseFloat(e.target.value);
+                          setCommissionRate(isNaN(val) ? 0 : val);
+                        }}
                         className="bg-slate-950/50 border-slate-800 text-slate-100 pr-8 focus:ring-primary focus:border-primary"
                       />
                       <div className="absolute right-3 top-2.5 text-xs text-slate-500">

--- a/src/app/settings/components/formSchema.ts
+++ b/src/app/settings/components/formSchema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const userSettingsSchema = z
+  .object({
+    taxStatus: z.enum(["filer", "non-filer"]),
+    commissionRate: z.coerce
+      .number({ invalid_type_error: "Commission rate must be a number" })
+      .min(0, "Commission rate cannot be negative"),
+    isCommissionPercentage: z.boolean(),
+  })
+  .refine(
+    (data) => !(data.isCommissionPercentage && data.commissionRate > 100),
+    {
+      message: "Percentage commission rate cannot exceed 100%",
+      path: ["commissionRate"],
+    }
+  );
+
+export type UserSettingsFormValues = z.infer<typeof userSettingsSchema>;

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -1,0 +1,10 @@
+import { getPortfolios } from "@/actions/portfolio/portfolioActions";
+import PortfoliosSidebar from "@/app/portfolio/[portfolioId]/components/PortfoliosSidebar";
+import { Portfolio } from "@/db/schema";
+
+export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
+  const response = await getPortfolios();
+  const portfolioList = response?.success ? (response.data as Portfolio[]) : [];
+
+  return <PortfoliosSidebar portfolioList={portfolioList}>{children}</PortfoliosSidebar>;
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,20 @@
+import { Metadata } from "next";
+import { getUserSettings } from "@/actions/userSettings/userSettingsActions";
+import UserSettingsForm from "./components/UserSettingsForm";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Configure your tax profile, default brokerage commissions, and automated financial workflows.",
+  alternates: {
+    canonical: "/settings",
+  },
+};
+
+export default async function SettingsPage() {
+  const settingsResponse = await getUserSettings();
+  const settings = settingsResponse.success ? settingsResponse.data : null;
+
+  return <UserSettingsForm initialSettings={settings ?? null} />;
+}

--- a/src/components/layout/ConditionalLayout.tsx
+++ b/src/components/layout/ConditionalLayout.tsx
@@ -10,7 +10,9 @@ interface ConditionalLayoutProps {
 
 export const ConditionalLayout = ({ children }: ConditionalLayoutProps) => {
   const pathname = usePathname();
-  const isPortfolioPage = pathname.startsWith("/portfolio") || pathname.startsWith("/settings");
+  const isPortfolioPage =
+    /^\/portfolio(?:\/|$)/.test(pathname) ||
+    /^\/settings(?:\/|$)/.test(pathname);
 
   if (isPortfolioPage) {
     // Portfolio pages have their own sidebar layout, no header/footer needed

--- a/src/components/layout/ConditionalLayout.tsx
+++ b/src/components/layout/ConditionalLayout.tsx
@@ -10,7 +10,7 @@ interface ConditionalLayoutProps {
 
 export const ConditionalLayout = ({ children }: ConditionalLayoutProps) => {
   const pathname = usePathname();
-  const isPortfolioPage = pathname.startsWith("/portfolio");
+  const isPortfolioPage = pathname.startsWith("/portfolio") || pathname.startsWith("/settings");
 
   if (isPortfolioPage) {
     // Portfolio pages have their own sidebar layout, no header/footer needed

--- a/src/components/molecules/PortfolioItemActions/PortfolioItemActions.tsx
+++ b/src/components/molecules/PortfolioItemActions/PortfolioItemActions.tsx
@@ -23,6 +23,7 @@ import posthog from "posthog-js";
 import { useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { toast } from "../Toast";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface PortfolioItemActionsProps {
   portfolio: Portfolio;
@@ -34,6 +35,7 @@ const PortfolioItemActions = ({ portfolio, className }: PortfolioItemActionsProp
   const [isDeleting, setIsDeleting] = useState(false);
   const router = useRouter();
   const pathname = usePathname();
+  const queryClient = useQueryClient();
 
   const holdingsFilter = useHoldingsFilter(portfolio.id);
   const setHoldingsFilter = usePortfolioStore((state) => state.setHoldingsFilter);
@@ -44,6 +46,7 @@ const PortfolioItemActions = ({ portfolio, className }: PortfolioItemActionsProp
     try {
       const response = await deletePortfolioAction(portfolio.id);
       if (response.success) {
+        queryClient.invalidateQueries({ queryKey: ["portfolios"] });
         toast({
           type: "success",
           title: "Portfolio Deleted Successfully",

--- a/src/components/organisms/ImportTransactions/components/ImportTransactionsContent.tsx
+++ b/src/components/organisms/ImportTransactions/components/ImportTransactionsContent.tsx
@@ -7,6 +7,8 @@ import { toast } from "@/components/molecules/Toast";
 import MultipleTransactionsReview from "@/components/organisms/ImportTransactions/components/MultipleTransactionsReview/MultipleTransactionsReview";
 import { Card } from "@/components/ui/card";
 import { TransactionSchemaType } from "@/types";
+import { usePortfolio } from "@/utils/hooks/usePortfolio";
+import { useUserSettings } from "@/utils/hooks/useUserSettings";
 import { useParams } from "next/navigation";
 import posthog from "posthog-js";
 import React, { useState } from "react";
@@ -32,6 +34,9 @@ export function ImportTransactionsContent({ onCloseDialog }: ImportTransactionsC
 
   const params = useParams<{ portfolioId: string }>();
   const portfolioId = parseInt(params.portfolioId, 10);
+
+  const { settings } = useUserSettings();
+  const { portfolios } = usePortfolio();
 
   const handleNext = () => {
     if (currentStep < steps.length) {
@@ -76,9 +81,37 @@ export function ImportTransactionsContent({ onCloseDialog }: ImportTransactionsC
       const response = await parseRawTransactions(inputFormData);
 
       if (response.success && response.data) {
+        const portfolio = portfolios?.find((p) => p.id === portfolioId);
+        let effectiveTaxStatus: "filer" | "non-filer" = "filer";
+        if (portfolio && !portfolio.useGlobalTax) {
+          effectiveTaxStatus = portfolio.taxStatus;
+        } else if (settings) {
+          effectiveTaxStatus = settings.taxStatus;
+        }
+
         //Attach portfolio ID with each transaction.
         response.data.forEach((transaction: any) => {
           transaction.portfolioId = portfolioId;
+
+          // Compute and pre-fill commission & taxes if not parsed or is 0
+          if (
+            transaction.commissionAndTaxes === undefined ||
+            transaction.commissionAndTaxes === null ||
+            transaction.commissionAndTaxes === 0
+          ) {
+            if (transaction.type === "dividend") {
+              transaction.commissionAndTaxes = effectiveTaxStatus === "filer" ? 15 : 30;
+              transaction.isCommissionPercentage = true;
+            } else if (transaction.type === "buy" || transaction.type === "sell") {
+              if (settings) {
+                transaction.commissionAndTaxes = settings.commissionRate;
+                transaction.isCommissionPercentage = settings.isCommissionPercentage;
+              } else {
+                transaction.commissionAndTaxes = 0.15;
+                transaction.isCommissionPercentage = true;
+              }
+            }
+          }
 
           if (transaction.isCommissionPercentage === undefined) {
             transaction.isCommissionPercentage = false;

--- a/src/components/organisms/ImportTransactions/components/ImportTransactionsContent.tsx
+++ b/src/components/organisms/ImportTransactions/components/ImportTransactionsContent.tsx
@@ -35,8 +35,8 @@ export function ImportTransactionsContent({ onCloseDialog }: ImportTransactionsC
   const params = useParams<{ portfolioId: string }>();
   const portfolioId = parseInt(params.portfolioId, 10);
 
-  const { settings } = useUserSettings();
-  const { portfolios } = usePortfolio();
+  const { settings, isLoading: isLoadingSettings } = useUserSettings();
+  const { portfolios, isLoadingPortfolios } = usePortfolio();
 
   const handleNext = () => {
     if (currentStep < steps.length) {
@@ -75,6 +75,14 @@ export function ImportTransactionsContent({ onCloseDialog }: ImportTransactionsC
   };
 
   const handleDataSubmit = async () => {
+    if (isLoadingSettings || isLoadingPortfolios) {
+      toast({
+        type: "error",
+        title: "Loading data",
+        description: "Please wait while settings and portfolios are loading.",
+      });
+      return;
+    }
     // Modified to use inputFormData
     setIsLoading(true);
     try {
@@ -146,7 +154,7 @@ export function ImportTransactionsContent({ onCloseDialog }: ImportTransactionsC
           <div className={getStepClasses(1)}>
             <MultipleTransactionsInput
               onSubmit={handleDataSubmit}
-              isLoading={isLoading}
+              isLoading={isLoading || isLoadingSettings || isLoadingPortfolios}
               initialData={inputFormData}
               onDataChange={handleInputDataChange}
             />

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -2,8 +2,10 @@ export {
   portfolioTable,
   transactionTable,
   stockPerformanceTable,
+  userSettingsTable,
   type Portfolio,
   type Transaction,
   type StockPerformance,
+  type UserSettings,
 } from "@/db/userdb-schema";
 

--- a/src/db/userdb-schema.ts
+++ b/src/db/userdb-schema.ts
@@ -6,6 +6,8 @@ export const portfolioTable = pgTable("portfolioTable", {
   userId: text("user_id").notNull(),
   backgroundColor: text("background_color").notNull(),
   emoji: text("emoji").notNull(),
+  useGlobalTax: boolean("use_global_tax").notNull().default(true),
+  taxStatus: text("tax_status", { enum: ["filer", "non-filer"] }).notNull().default("filer"),
   createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
 });
@@ -52,9 +54,20 @@ export const stockPerformanceTable = pgTable(
   (table) => [unique().on(table.portfolioId, table.stockSymbol)]
 );
 
+export const userSettingsTable = pgTable("userSettingsTable", {
+  userId: text("user_id").primaryKey(),
+  taxStatus: text("tax_status", { enum: ["filer", "non-filer"] }).notNull().default("filer"),
+  commissionRate: real("commission_rate").notNull().default(0),
+  isCommissionPercentage: boolean("is_commission_percentage").notNull().default(true),
+  createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
+});
+
 export type UserPortfolio = typeof portfolioTable.$inferSelect;
 export type UserTransaction = typeof transactionTable.$inferSelect;
 export type UserStockPerformance = typeof stockPerformanceTable.$inferSelect;
+export type UserSettings = typeof userSettingsTable.$inferSelect;
 export type Portfolio = UserPortfolio;
 export type Transaction = UserTransaction;
 export type StockPerformance = UserStockPerformance;
+export type UserSettingsType = UserSettings;

--- a/src/db/userdb-schema.ts
+++ b/src/db/userdb-schema.ts
@@ -57,7 +57,7 @@ export const stockPerformanceTable = pgTable(
 export const userSettingsTable = pgTable("userSettingsTable", {
   userId: text("user_id").primaryKey(),
   taxStatus: text("tax_status", { enum: ["filer", "non-filer"] }).notNull().default("filer"),
-  commissionRate: real("commission_rate").notNull().default(0),
+  commissionRate: real("commission_rate").notNull().default(0.15),
   isCommissionPercentage: boolean("is_commission_percentage").notNull().default(true),
   createdAt: timestamp("created_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true, mode: "date" }).notNull().defaultNow(),
@@ -70,4 +70,3 @@ export type UserSettings = typeof userSettingsTable.$inferSelect;
 export type Portfolio = UserPortfolio;
 export type Transaction = UserTransaction;
 export type StockPerformance = UserStockPerformance;
-export type UserSettingsType = UserSettings;

--- a/src/utils/hooks/usePortfolio.ts
+++ b/src/utils/hooks/usePortfolio.ts
@@ -1,10 +1,12 @@
 import { createPortfolio, getPortfolios, updatePortfolio } from "@/actions/portfolio/portfolioActions";
 import { toast } from "@/components/molecules/Toast";
 import { Portfolio } from "@/db/schema";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { handleServerPromise } from "../helpers/server";
 
 export const usePortfolio = () => {
+  const queryClient = useQueryClient();
+
   const portfolios = useQuery({
     queryKey: ["portfolios"],
     queryFn: async () => {
@@ -21,6 +23,7 @@ export const usePortfolio = () => {
     mutationFn: (data: Omit<Portfolio, "userId" | "createdAt" | "updatedAt" | "id">) =>
       handleServerPromise(createPortfolio(data)),
     onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["portfolios"] });
       toast({
         type: "success",
         title: "Portfolio Created Successfully.",
@@ -36,6 +39,7 @@ export const usePortfolio = () => {
   const updatePortfolioMutation = useMutation({
     mutationFn: (data: Portfolio) => handleServerPromise(updatePortfolio(data)),
     onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["portfolios"] });
       toast({
         type: "success",
         title: "Portfolio Updated Successfully.",

--- a/src/utils/hooks/usePortfolio.ts
+++ b/src/utils/hooks/usePortfolio.ts
@@ -1,10 +1,22 @@
-import { createPortfolio, updatePortfolio } from "@/actions/portfolio/portfolioActions";
+import { createPortfolio, getPortfolios, updatePortfolio } from "@/actions/portfolio/portfolioActions";
 import { toast } from "@/components/molecules/Toast";
 import { Portfolio } from "@/db/schema";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { handleServerPromise } from "../helpers/server";
 
 export const usePortfolio = () => {
+  const portfolios = useQuery({
+    queryKey: ["portfolios"],
+    queryFn: async () => {
+      const result = await getPortfolios();
+      if (result.success && result.data) {
+        return result.data as Portfolio[];
+      }
+      throw new Error(result.message || "Failed to load portfolios");
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
   const createPortfolioMutation = useMutation({
     mutationFn: (data: Omit<Portfolio, "userId" | "createdAt" | "updatedAt" | "id">) =>
       handleServerPromise(createPortfolio(data)),
@@ -36,6 +48,8 @@ export const usePortfolio = () => {
   });
 
   return {
+    portfolios: portfolios.data ?? [],
+    isLoadingPortfolios: portfolios.isLoading,
     createPortfolioMutation,
     updatePortfolioMutation,
   };

--- a/src/utils/hooks/usePortfolio.ts
+++ b/src/utils/hooks/usePortfolio.ts
@@ -3,19 +3,23 @@ import { toast } from "@/components/molecules/Toast";
 import { Portfolio } from "@/db/schema";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { handleServerPromise } from "../helpers/server";
+import { useAuth } from "@clerk/nextjs";
 
 export const usePortfolio = () => {
   const queryClient = useQueryClient();
+  const { userId } = useAuth();
 
   const portfolios = useQuery({
-    queryKey: ["portfolios"],
+    queryKey: ["portfolios", userId],
     queryFn: async () => {
+      if (!userId) throw new Error("User not authenticated");
       const result = await getPortfolios();
       if (result.success && result.data) {
         return result.data as Portfolio[];
       }
       throw new Error(result.message || "Failed to load portfolios");
     },
+    enabled: !!userId,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -23,7 +27,7 @@ export const usePortfolio = () => {
     mutationFn: (data: Omit<Portfolio, "userId" | "createdAt" | "updatedAt" | "id">) =>
       handleServerPromise(createPortfolio(data)),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["portfolios"] });
+      queryClient.invalidateQueries({ queryKey: ["portfolios", userId] });
       toast({
         type: "success",
         title: "Portfolio Created Successfully.",
@@ -39,7 +43,7 @@ export const usePortfolio = () => {
   const updatePortfolioMutation = useMutation({
     mutationFn: (data: Portfolio) => handleServerPromise(updatePortfolio(data)),
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["portfolios"] });
+      queryClient.invalidateQueries({ queryKey: ["portfolios", userId] });
       toast({
         type: "success",
         title: "Portfolio Updated Successfully.",

--- a/src/utils/hooks/useUserSettings.ts
+++ b/src/utils/hooks/useUserSettings.ts
@@ -4,19 +4,23 @@ import { getUserSettings, updateUserSettings } from "@/actions/userSettings/user
 import { UserSettings } from "@/db/schema";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "@/components/molecules/Toast";
+import { useAuth } from "@clerk/nextjs";
 
 export const useUserSettings = () => {
   const queryClient = useQueryClient();
+  const { userId } = useAuth();
 
   const settings = useQuery({
-    queryKey: ["userSettings"],
+    queryKey: ["userSettings", userId],
     queryFn: async () => {
+      if (!userId) throw new Error("User not authenticated");
       const result = await getUserSettings();
       if (result.success && result.data) {
         return result.data as UserSettings;
       }
       throw new Error(result.message || "Failed to load user settings");
     },
+    enabled: !!userId,
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 
@@ -33,7 +37,7 @@ export const useUserSettings = () => {
         type: "success",
         title: "Settings updated successfully!",
       });
-      queryClient.invalidateQueries({ queryKey: ["userSettings"] });
+      queryClient.invalidateQueries({ queryKey: ["userSettings", userId] });
     },
     onError: (error: Error) => {
       toast({

--- a/src/utils/hooks/useUserSettings.ts
+++ b/src/utils/hooks/useUserSettings.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { getUserSettings, updateUserSettings } from "@/actions/userSettings/userSettingsActions";
+import { UserSettings } from "@/db/schema";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "@/components/molecules/Toast";
+
+export const useUserSettings = () => {
+  const queryClient = useQueryClient();
+
+  const settings = useQuery({
+    queryKey: ["userSettings"],
+    queryFn: async () => {
+      const result = await getUserSettings();
+      if (result.success && result.data) {
+        return result.data as UserSettings;
+      }
+      throw new Error(result.message || "Failed to load user settings");
+    },
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  const updateSettingsMutation = useMutation({
+    mutationFn: async (data: Omit<UserSettings, "userId" | "createdAt" | "updatedAt">) => {
+      const response = await updateUserSettings(data);
+      if (!response.success) {
+        throw new Error(response.message || "Failed to update settings");
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      toast({
+        type: "success",
+        title: "Settings updated successfully!",
+      });
+      queryClient.invalidateQueries({ queryKey: ["userSettings"] });
+    },
+    onError: (error: Error) => {
+      toast({
+        type: "error",
+        title: "Failed to update settings",
+        description: error.message,
+      });
+    },
+  });
+
+  return {
+    settings: settings.data ?? null,
+    isLoading: settings.isLoading,
+    isError: settings.isError,
+    updateSettings: updateSettingsMutation,
+  };
+};

--- a/src/utils/hooks/useUserSettings.ts
+++ b/src/utils/hooks/useUserSettings.ts
@@ -38,6 +38,7 @@ export const useUserSettings = () => {
         title: "Settings updated successfully!",
       });
       queryClient.invalidateQueries({ queryKey: ["userSettings", userId] });
+      queryClient.invalidateQueries({ queryKey: ["portfolios", userId] });
     },
     onError: (error: Error) => {
       toast({


### PR DESCRIPTION
## What changed

* **User Settings CRUD & Caching:** Added the `userSettingsTable` schema with database queries (`getUserSettings` / `updateUserSettings`) and query caching.
* **Financial Settings Page:** Added a new `/settings` dashboard layout and minimal card forms (`UserSettingsForm`) to configure default tax status (Filer/Non-Filer) and brokerage commission rules.
* **Portfolio Overrides:** Added `useGlobalTax` toggle and local `taxStatus` overrides to the portfolio creation and edit forms.
* **Automated Calculations (Manual & AI):**
    * Updated the manual `TransactionForm` to dynamically pre-fill defaults based on selected transaction type.
    * Updated the AI transaction parser to automatically pre-fill settings-based commission and tax fields before rendering review cards.
* **Sidebar Integration:** Integrated the settings configuration page path into the main navigation layout and sidebar footer.

## Why

Relying entirely on AI text parsing or manual entry to capture highly variable tax rates and broker commission fees for every transaction is inefficient. This feature allows users to configure profiles once, automating downstream financial computations and reducing data entry friction.

Closes #30 

## Testing

* **Verified migrations:** Applied correctly on the local database (`pnpm db:user:migrate`).
* **UI Validation:** Validated form state changes, AI parser default injections, and settings overrides in the UI.
* **Code Quality:** Ran type checks (`pnpm lint:types`) and styling linter (`pnpm lint`) locally to confirm all checks pass.

## Screenshot

https://github.com/user-attachments/assets/a5681572-ad81-44ac-bbee-20f948484058

## Checklist

- [x] PR targets `develop` (not `main`)
- [x] I'm assigned to the linked issue
- [x] `pnpm lint` and `pnpm lint:types` pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Settings page for per-user tax profile and brokerage commission rules.
  * Added portfolio tax settings to choose between global tax rules and local overrides.
* **Enhancements**
  * Automatically pre-fills transaction commission/tax values during creation and import based on the effective (global vs local) tax configuration.
  * Added a dedicated “Tax Settings” section to the portfolio creation/edit form, including filer/non-filer selection and global-tax toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->